### PR TITLE
Add RSS pipeline and deals page: fail pipeline on errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "pipeline": "node pipelines/run-all.mjs || exit 0"
+    "pipeline": "node pipelines/run-all.mjs"
   },
   "dependencies": {
     "astro": "^4.13.0",

--- a/pipelines/run-all.mjs
+++ b/pipelines/run-all.mjs
@@ -6,7 +6,7 @@ async function main(){
   const tasks = [
     import(path.join(__dirname, 'rss.mjs')).then(m => m.run())
   ];
-  await Promise.allSettled(tasks);
+  await Promise.all(tasks);
   console.log('[pipeline] all done');
 }
-main().catch(e => { console.error(e); process.exit(0); });
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- fail pipeline when tasks reject by using `Promise.all`
- remove silent exit from `npm run pipeline`

## Testing
- `npm run pipeline`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b97018e2b48326a7f747af1c9bdb5b