### PR TITLE
feat(prices): add rakuten price tracker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
       - run: npm ci
-      - name: Run pipeline (RSS → deals.json)
+      - name: Run pipeline
         run: npm run pipeline
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3

--- a/pipelines/prices-rakuten.mjs
+++ b/pipelines/prices-rakuten.mjs
@@ -1,0 +1,69 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs/promises';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.join(__dirname, '..');
+const skuPath = path.join(rootDir, 'src', 'data', 'skus.json');
+const outPath = path.join(rootDir, 'src', 'data', 'prices', 'today.json');
+
+export async function run() {
+  const appId = process.env.RAKUTEN_APP_ID;
+  if (!appId) {
+    console.warn('[prices] RAKUTEN_APP_ID is missing');
+    return;
+  }
+  let skus = [];
+  try {
+    const raw = await fs.readFile(skuPath, 'utf-8');
+    skus = JSON.parse(raw);
+  } catch (e) {
+    console.error('[prices] failed to read skus.json', e);
+    return;
+  }
+
+  const items = [];
+  for (const sku of skus) {
+    try {
+      const url = new URL('https://app.rakuten.co.jp/services/api/IchibaItem/Search/20220601');
+      url.searchParams.set('format', 'json');
+      url.searchParams.set('applicationId', appId);
+      url.searchParams.set('keyword', sku.q);
+      url.searchParams.set('hits', '30');
+
+      const res = await fetch(url);
+      const data = await res.json();
+      const candidates = (data.Items || []).map(it => it.Item);
+      const filtered = candidates.filter(it => {
+        const title = it.itemName?.toLowerCase() || '';
+        if (sku.filters && sku.filters.some(f => !title.includes(f.toLowerCase()))) return false;
+        if (sku.brandHints && !sku.brandHints.some(b => title.includes(b.toLowerCase()))) return false;
+        return true;
+      }).map(it => ({
+        title: it.itemName,
+        shopName: it.shopName,
+        itemUrl: it.itemUrl,
+        price: Number(it.itemPrice),
+        pointRate: Number(it.pointRate) || 0,
+        imageUrl: it.mediumImageUrls?.[0]?.imageUrl,
+        itemCode: it.itemCode
+      }));
+      filtered.sort((a, b) => (a.price - a.price * a.pointRate / 100) - (b.price - b.price * b.pointRate / 100));
+      const best = filtered[0];
+      items.push({
+        skuId: sku.id,
+        bestPrice: best?.price ?? null,
+        bestShop: best?.shopName ?? null,
+        list: filtered
+      });
+    } catch (e) {
+      console.error('[prices] sku failed', sku.id, e);
+      items.push({ skuId: sku.id, bestPrice: null, bestShop: null, list: [] });
+    }
+  }
+
+  const out = { updatedAt: new Date().toISOString(), items };
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  await fs.writeFile(outPath, JSON.stringify(out, null, 2));
+  console.log('[prices] wrote', outPath);
+}

--- a/pipelines/run-all.mjs
+++ b/pipelines/run-all.mjs
@@ -4,9 +4,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function main(){
   const tasks = [
-    import(path.join(__dirname, 'rss.mjs')).then(m => m.run())
+    import(path.join(__dirname, 'rss.mjs')).then(m => m.run()),
+    import(path.join(__dirname, 'prices-rakuten.mjs')).then(m => m.run()),
   ];
-  await Promise.all(tasks);
+  const results = await Promise.allSettled(tasks);
+  results.forEach(r => {
+    if (r.status === 'rejected') {
+      console.error('[pipeline] task failed', r.reason);
+    }
+  });
   console.log('[pipeline] all done');
 }
 main().catch(e => { console.error(e); process.exit(1); });

--- a/src/data/prices/today.json
+++ b/src/data/prices/today.json
@@ -1,0 +1,37 @@
+{
+  "updatedAt": "1970-01-01T00:00:00.000Z",
+  "items": [
+    {
+      "skuId": "ssd_1tb",
+      "bestPrice": 10000,
+      "bestShop": "Dummy Shop",
+      "list": [
+        {
+          "title": "SanDisk 1TB SSD",
+          "shopName": "Dummy Shop",
+          "itemUrl": "https://example.com/ssd",
+          "price": 10000,
+          "pointRate": 0,
+          "imageUrl": "https://example.com/ssd.jpg",
+          "itemCode": "dummy1"
+        }
+      ]
+    },
+    {
+      "skuId": "sd_128",
+      "bestPrice": 2000,
+      "bestShop": "Example Store",
+      "list": [
+        {
+          "title": "SanDisk 128GB SD",
+          "shopName": "Example Store",
+          "itemUrl": "https://example.com/sd",
+          "price": 2000,
+          "pointRate": 0,
+          "imageUrl": "https://example.com/sd.jpg",
+          "itemCode": "dummy2"
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/skus.json
+++ b/src/data/skus.json
@@ -1,0 +1,4 @@
+[
+  { "id": "ssd_1tb", "q": "外付けSSD 1TB", "filters": ["USB 3", "1TB"], "brandHints": ["SanDisk", "Crucial", "ADATA"] },
+  { "id": "sd_128", "q": "SDカード 128GB", "filters": ["UHS-I"], "brandHints": ["SanDisk", "Kioxia"] }
+]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,8 @@
 import "../styles/global.css";
 const tools = [
   { href: "calculators/", title: "計算機ハブ", desc: "完全静的・ノーAPI・壊れにくい常緑装置" },
-  { href: "deals/", title: "今日のセールまとめ", desc: "合法RSSを自動集約。毎日自動更新" }
+  { href: "deals/", title: "今日のセールまとめ", desc: "合法RSSを自動集約。毎日自動更新" },
+  { href: "prices/", title: "今日の最安値", desc: "楽天市場の価格トラッカー" }
 ];
 ---
 <html lang="ja">

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -1,0 +1,52 @@
+---
+import "../../styles/global.css";
+import data from "../../data/prices/today.json";
+import skus from "../../data/skus.json";
+const { sku } = Astro.params;
+const skuInfo = skus.find(s => s.id === sku);
+const priceInfo = data.items.find(i => i.skuId === sku);
+
+export function getStaticPaths() {
+  return skus.map(s => ({ params: { sku: s.id } }));
+}
+---
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <base href={import.meta.env.BASE_URL} />
+    <title>{skuInfo ? skuInfo.q : sku}の価格表</title>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>{skuInfo ? skuInfo.q : sku}</h1>
+      <p class="small">価格・在庫は変動します。リンク先の最新情報をご確認ください。</p>
+      <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
+      {skuInfo && (
+        <div>
+          <h2>仕様</h2>
+          <ul>
+            {skuInfo.filters && <li>フィルタ: {skuInfo.filters.join(', ')}</li>}
+            {skuInfo.brandHints && <li>ブランド候補: {skuInfo.brandHints.join(', ')}</li>}
+          </ul>
+        </div>
+      )}
+      {priceInfo && (
+        <table>
+          <thead>
+            <tr><th>ショップ</th><th>価格</th><th>ポイント倍率</th></tr>
+          </thead>
+          <tbody>
+            {priceInfo.list.map(it => (
+              <tr>
+                <td><a href={it.itemUrl} target="_blank" rel="nofollow noopener">{it.shopName}</a></td>
+                <td>{it.price}円</td>
+                <td>{it.pointRate}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  </body>
+</html>

--- a/src/pages/prices/index.astro
+++ b/src/pages/prices/index.astro
@@ -1,0 +1,29 @@
+---
+import "../../styles/global.css";
+import data from "../../data/prices/today.json";
+import skus from "../../data/skus.json";
+const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
+---
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <base href={import.meta.env.BASE_URL} />
+    <title>今日の最安値ランキング</title>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>今日の最安値ランキング</h1>
+      <p class="small">価格・在庫は変動します。リンク先の最新情報をご確認ください。</p>
+      <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
+      <ul>
+        {data.items.map(it => (
+          <li>
+            <a href={`./${it.skuId}/`}>{skuMap[it.skuId]?.q ?? it.skuId}</a>
+            : {it.bestPrice}円 ({it.bestShop})
+          </li>
+        ))}
+      </ul>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Rakuten Ichiba price pipeline and sample SKU data
- expose daily price ranking and detail pages under `/prices/`
- integrate pipeline into workflow and homepage menu

## Testing
- `npm test` *(fails: Missing script)*
- `npm run pipeline`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bab12452448326b463155d655e0103