### PR TITLE
feat: refresh landing copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,24 @@
 ---
 import "../styles/global.css";
 const tools = [
-  { href: "calculators/", title: "計算機ハブ", desc: "完全静的・ノーAPI・壊れにくい常緑装置" },
-  { href: "deals/", title: "今日のセールまとめ", desc: "合法RSSを自動集約。毎日自動更新" },
-  { href: "prices/", title: "今日の最安値", desc: "楽天市場の価格トラッカー" }
+  {
+    href: "calculators/",
+    title: "計算機ハブ",
+    desc: "完全静的・ノーAPI・壊れにくい常緑装置",
+    btn: "計算する",
+  },
+  {
+    href: "deals/",
+    title: "今日のセールまとめ",
+    desc: "合法RSSを自動集約。毎日自動更新",
+    btn: "今日のお得を見る",
+  },
+  {
+    href: "prices/",
+    title: "今日の最安値",
+    desc: "楽天市場の価格トラッカー",
+    btn: "開く",
+  },
 ];
 ---
 <html lang="ja">
@@ -15,14 +30,13 @@ const tools = [
   </head>
   <body>
     <div class="wrap">
-      <h1>自動化工場 v0.1</h1>
-      <p class="small">テンプレから装置を量産 → 完全放置で回す。</p>
-      <div class="grid" style="margin-top:20px">
+      <h1>買う前の1分チェック。</h1>
+      <p class="small">よく使う計算機と、今日のお得情報をシンプルに。毎日自動更新／公式ソースのみ。価格は取得時点の参考値です。</p>
         {tools.map(t => (
           <a class="card" href={t.href}>
             <h2>{t.title}</h2>
             <p>{t.desc}</p>
-            <span class="btn">開く</span>
+            <span class="btn">{t.btn}</span>
           </a>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- update landing heading and description to emphasize practical trust tone
- provide specific CTA labels for calculator and deals cards

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bba2f32a8c83268d02f6ddad409bae