### PR TITLE
chore: unify CI check names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   test-build:
+    name: test-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: build-and-deploy
+name: CI
 on:
   push:
     branches: [ main ]
@@ -12,7 +12,8 @@ permissions:
   id-token: write
 
 jobs:
-  build:
+  test-build:
+    name: test-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +27,7 @@ jobs:
         with: { path: "dist" }
 
   deploy:
-    needs: build
+    needs: test-build
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- unify GitHub Actions workflow names so checks appear as `CI / test-build`
- rename deploy workflow job and update dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bbd4f199dc83268145e5f4bd6e0f8e