### PR TITLE
chore: update price tracker intro text

### DIFF
--- a/src/pages/prices/index.astro
+++ b/src/pages/prices/index.astro
@@ -9,12 +9,13 @@ const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <base href={import.meta.env.BASE_URL} />
-    <title>今日の最安値ランキング</title>
+    <title>今日の最安“候補”</title>
   </head>
   <body>
     <div class="wrap">
-      <h1>今日の最安値ランキング</h1>
-      <p class="small">価格・在庫は変動します。リンク先の最新情報をご確認ください。</p>
+      <h1>今日の最安“候補”</h1>
+      <p class="small">対象カテゴリから毎日、自動で候補を抽出し、価格とポイント相当を目安に並べ替えています。</p>
+      <p class="small">表示価格は取得時点の参考値です。購入前に必ずリンク先の最新情報をご確認ください。</p>
       <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
       <ul>
         {data.items.map(it => (


### PR DESCRIPTION
## Summary
- clarify copy on the prices top page to emphasize candidate status and reference-only pricing

## Testing
- `npm test`
- `npm run build`
- `curl -I https://panappuom.github.io/calc-hub/prices/` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bba3256dbc832685940ff3ad601e6d