### PR TITLE
feat: add top links for prices and calculators

### DIFF
--- a/src/pages/calculators.astro
+++ b/src/pages/calculators.astro
@@ -10,7 +10,7 @@ import "../styles/global.css";
   </head>
   <body>
     <div class="wrap">
-      <a href="./" class="small">← 戻る</a>
+      <a href="./" class="small">← トップ</a>
       <h1>かんたん計算室</h1>
       <div class="grid">
 

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -19,6 +19,7 @@ export function getStaticPaths() {
   </head>
   <body>
     <div class="wrap">
+        <a href="./" class="small">← トップ</a>
       <h1>{skuInfo ? skuInfo.q : sku} – 価格一覧</h1>
       <p>ショップ別の価格を一覧しています。並び順は目安（価格・ポイント相当）です。</p>
       <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>

--- a/src/pages/prices/index.astro
+++ b/src/pages/prices/index.astro
@@ -13,6 +13,7 @@ const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
   </head>
   <body>
     <div class="wrap">
+        <a href="./" class="small">← トップ</a>
       <h1>今日の最安“候補”</h1>
       <p class="small">対象カテゴリから毎日、自動で候補を抽出し、価格とポイント相当を目安に並べ替えています。</p>
       <p class="small">表示価格は取得時点の参考値です。購入前に必ずリンク先の最新情報をご確認ください。</p>


### PR DESCRIPTION
## Summary
- add "← トップ" navigation link on prices pages
- unify calculators page back link label to "← トップ"

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3ef6d7808326a9a000d72c1e23aa