### PR TITLE
fix: mirror Rakuten history on API failure

### DIFF
--- a/pipelines/prices-rakuten.mjs
+++ b/pipelines/prices-rakuten.mjs
@@ -68,6 +68,12 @@ export async function run() {
 
   if (successCount === 0) {
     console.warn('[prices] all fetches failed, keep previous data');
+    try {
+      await fs.mkdir(publicHistoryDir, { recursive: true });
+      await fs.cp(historyDir, publicHistoryDir, { recursive: true });
+    } catch (e) {
+      console.warn('[prices] failed to mirror history', e);
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- ensure price-history assets are copied when all Rakuten fetches fail

## Testing
- `npm test`
- `RAKUTEN_APP_ID=dummy node -e "import('./pipelines/prices-rakuten.mjs').then(m=>m.run())"`


------
https://chatgpt.com/codex/tasks/task_e_68bd4f8c19348326a0d282b38bcf4b42