### PR TITLE
Add Yahoo Shopping pipeline and merge ranking

### DIFF
--- a/pipelines/prices-merge.mjs
+++ b/pipelines/prices-merge.mjs
@@ -1,0 +1,83 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs/promises';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.join(__dirname, '..');
+const skuPath = path.join(rootDir, 'src', 'data', 'skus.json');
+const rakutenPath = path.join(rootDir, 'src', 'data', 'prices', 'rakuten.json');
+const yahooPath = path.join(rootDir, 'src', 'data', 'prices', 'yahoo.json');
+const outPath = path.join(rootDir, 'src', 'data', 'prices', 'today.json');
+
+async function readJson(p) {
+  try {
+    const raw = await fs.readFile(p, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function chooseBest(list) {
+  if (!list || list.length === 0) return null;
+  return list.reduce((best, cur) => {
+    const b = best.price - (best.price * (best.pointRate || 0)) / 100;
+    const c = cur.price - (cur.price * (cur.pointRate || 0)) / 100;
+    return c < b ? cur : best;
+  });
+}
+
+export async function run() {
+  let skus = [];
+  try {
+    const raw = await fs.readFile(skuPath, 'utf-8');
+    skus = JSON.parse(raw);
+  } catch (e) {
+    console.error('[prices] merge failed to read skus.json', e);
+    return;
+  }
+
+  const rakutenData = (await readJson(rakutenPath)) ?? { items: [], status: 'fail' };
+  const yahooData = (await readJson(yahooPath)) ?? { items: [], status: 'fail' };
+
+  const rakutenMap = Object.fromEntries(rakutenData.items.map(i => [i.skuId, i.list]));
+  const yahooMap = Object.fromEntries(yahooData.items.map(i => [i.skuId, i.list]));
+
+  const items = [];
+  for (const sku of skus) {
+    const listR = rakutenMap[sku.id] || [];
+    const listY = yahooMap[sku.id] || [];
+    const bestR = chooseBest(listR);
+    const bestY = chooseBest(listY);
+
+    let best = null;
+    let bestSource = null;
+    if (bestR && (!bestY || (bestR.price - (bestR.price * (bestR.pointRate || 0)) / 100) <= (bestY.price - (bestY.price * (bestY.pointRate || 0)) / 100))) {
+      best = bestR;
+      bestSource = 'rakuten';
+    } else if (bestY) {
+      best = bestY;
+      bestSource = 'yahoo';
+    }
+
+    items.push({
+      skuId: sku.id,
+      bestPrice: best?.price ?? null,
+      bestShop: best?.shopName ?? null,
+      bestSource,
+      list: { rakuten: listR, yahoo: listY },
+    });
+  }
+
+  const out = {
+    updatedAt: new Date().toISOString(),
+    sourceStatus: {
+      rakuten: rakutenData.status ?? 'fail',
+      yahoo: yahooData.status ?? 'fail',
+    },
+    items,
+  };
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  await fs.writeFile(outPath, JSON.stringify(out, null, 2));
+  console.log('[prices] wrote', outPath);
+}

--- a/pipelines/run-all.mjs
+++ b/pipelines/run-all.mjs
@@ -3,21 +3,22 @@ import path from 'path';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function main(){
-  const tasks = [
-    import(path.join(__dirname, 'rss.mjs')).then(m => m.run()),
+  const rss = import(path.join(__dirname, 'rss.mjs')).then(m => m.run());
+  const priceTasks = [
     import(path.join(__dirname, 'prices-rakuten.mjs')).then(m => m.run()),
+    import(path.join(__dirname, 'prices-yahoo.mjs')).then(m => m.run()),
   ];
-  const results = await Promise.allSettled(tasks);
-  let hasFailure = false;
-  results.forEach(r => {
+  const rssRes = await Promise.allSettled([rss]);
+  if (rssRes[0]?.status === 'rejected') {
+    throw new Error('[pipeline] rss task failed');
+  }
+  const priceResults = await Promise.allSettled(priceTasks);
+  priceResults.forEach(r => {
     if (r.status === 'rejected') {
-      hasFailure = true;
-      console.error('[pipeline] task failed', r.reason);
+      console.error('[pipeline] price task failed', r.reason);
     }
   });
-  if (hasFailure) {
-    throw new Error('[pipeline] one or more tasks failed');
-  }
+  await import(path.join(__dirname, 'prices-merge.mjs')).then(m => m.run());
   console.log('[pipeline] all done');
 }
 main().catch(e => { console.error(e); process.exit(1); });

--- a/src/data/prices/rakuten.json
+++ b/src/data/prices/rakuten.json
@@ -1,0 +1,38 @@
+{
+  "updatedAt": "1970-01-01T00:00:00.000Z",
+  "status": "ok",
+  "items": [
+    {
+      "skuId": "ssd_1tb",
+      "bestPrice": 10000,
+      "bestShop": "Dummy Shop",
+      "list": [
+        {
+          "title": "SanDisk 1TB SSD",
+          "shopName": "Dummy Shop",
+          "itemUrl": "https://example.com/ssd",
+          "price": 10000,
+          "pointRate": 0,
+          "imageUrl": "https://example.com/ssd.jpg",
+          "itemCode": "dummy1"
+        }
+      ]
+    },
+    {
+      "skuId": "sd_128",
+      "bestPrice": 2000,
+      "bestShop": "Example Store",
+      "list": [
+        {
+          "title": "SanDisk 128GB SD",
+          "shopName": "Example Store",
+          "itemUrl": "https://example.com/sd",
+          "price": 2000,
+          "pointRate": 0,
+          "imageUrl": "https://example.com/sd.jpg",
+          "itemCode": "dummy2"
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/prices/today.json
+++ b/src/data/prices/today.json
@@ -1,37 +1,65 @@
 {
-  "updatedAt": "1970-01-01T00:00:00.000Z",
+  "updatedAt": "2025-09-07T09:32:57.091Z",
+  "sourceStatus": {
+    "rakuten": "ok",
+    "yahoo": "ok"
+  },
   "items": [
     {
       "skuId": "ssd_1tb",
-      "bestPrice": 10000,
-      "bestShop": "Dummy Shop",
-      "list": [
-        {
-          "title": "SanDisk 1TB SSD",
-          "shopName": "Dummy Shop",
-          "itemUrl": "https://example.com/ssd",
-          "price": 10000,
-          "pointRate": 0,
-          "imageUrl": "https://example.com/ssd.jpg",
-          "itemCode": "dummy1"
-        }
-      ]
+      "bestPrice": 9500,
+      "bestShop": "Yahoo Shop",
+      "bestSource": "yahoo",
+      "list": {
+        "rakuten": [
+          {
+            "title": "SanDisk 1TB SSD",
+            "shopName": "Dummy Shop",
+            "itemUrl": "https://example.com/ssd",
+            "price": 10000,
+            "pointRate": 0,
+            "imageUrl": "https://example.com/ssd.jpg",
+            "itemCode": "dummy1"
+          }
+        ],
+        "yahoo": [
+          {
+            "title": "SanDisk 1TB SSD",
+            "shopName": "Yahoo Shop",
+            "itemUrl": "https://yahoo.example.com/ssd",
+            "price": 9500,
+            "pointRate": 5
+          }
+        ]
+      }
     },
     {
       "skuId": "sd_128",
       "bestPrice": 2000,
       "bestShop": "Example Store",
-      "list": [
-        {
-          "title": "SanDisk 128GB SD",
-          "shopName": "Example Store",
-          "itemUrl": "https://example.com/sd",
-          "price": 2000,
-          "pointRate": 0,
-          "imageUrl": "https://example.com/sd.jpg",
-          "itemCode": "dummy2"
-        }
-      ]
+      "bestSource": "rakuten",
+      "list": {
+        "rakuten": [
+          {
+            "title": "SanDisk 128GB SD",
+            "shopName": "Example Store",
+            "itemUrl": "https://example.com/sd",
+            "price": 2000,
+            "pointRate": 0,
+            "imageUrl": "https://example.com/sd.jpg",
+            "itemCode": "dummy2"
+          }
+        ],
+        "yahoo": [
+          {
+            "title": "SanDisk 128GB SD",
+            "shopName": "Yahoo Store",
+            "itemUrl": "https://yahoo.example.com/sd",
+            "price": 2100,
+            "pointRate": 1
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/data/prices/yahoo.json
+++ b/src/data/prices/yahoo.json
@@ -1,0 +1,34 @@
+{
+  "updatedAt": "1970-01-01T00:00:00.000Z",
+  "status": "ok",
+  "items": [
+    {
+      "skuId": "ssd_1tb",
+      "bestPrice": 9500,
+      "bestShop": "Yahoo Shop",
+      "list": [
+        {
+          "title": "SanDisk 1TB SSD",
+          "shopName": "Yahoo Shop",
+          "itemUrl": "https://yahoo.example.com/ssd",
+          "price": 9500,
+          "pointRate": 5
+        }
+      ]
+    },
+    {
+      "skuId": "sd_128",
+      "bestPrice": 2100,
+      "bestShop": "Yahoo Store",
+      "list": [
+        {
+          "title": "SanDisk 128GB SD",
+          "shopName": "Yahoo Store",
+          "itemUrl": "https://yahoo.example.com/sd",
+          "price": 2100,
+          "pointRate": 1
+        }
+      ]
+    }
+  ]
+}

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -5,6 +5,7 @@ import skus from "../../data/skus.json";
 const { sku } = Astro.params;
 const skuInfo = skus.find(s => s.id === sku);
 const priceInfo = data.items.find(i => i.skuId === sku);
+const lists = priceInfo?.list || { rakuten: [], yahoo: [] };
 
 export function getStaticPaths() {
   return skus.map(s => ({ params: { sku: s.id } }));
@@ -23,6 +24,7 @@ export function getStaticPaths() {
       <h1>{skuInfo ? skuInfo.q : sku} – 価格一覧</h1>
       <p>ショップ別の価格を一覧しています。並び順は目安（価格・ポイント相当）です。</p>
       <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
+      <p class="small">Rakuten: {data.sourceStatus?.rakuten ?? 'n/a'} / Yahoo: {data.sourceStatus?.yahoo ?? 'n/a'}</p>
       {skuInfo && (
         <div>
           <h2>仕様</h2>
@@ -34,20 +36,44 @@ export function getStaticPaths() {
       )}
       {priceInfo && (
         <>
-          <table>
-            <thead>
-              <tr><th>ショップ</th><th>価格</th><th>ポイント倍率</th></tr>
-            </thead>
-            <tbody>
-              {priceInfo.list.map(it => (
-                <tr>
-                  <td>{it.shopName} <a href={it.itemUrl} target="_blank" rel="nofollow noopener">ショップで確認</a></td>
-                  <td>{it.price}円</td>
-                  <td>{it.pointRate}%</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          {lists.rakuten.length > 0 && (
+            <>
+              <h2>Rakuten</h2>
+              <table>
+                <thead>
+                  <tr><th>ショップ</th><th>価格</th><th>ポイント倍率</th></tr>
+                </thead>
+                <tbody>
+                  {lists.rakuten.map(it => (
+                    <tr>
+                      <td>{it.shopName} <a href={it.itemUrl} target="_blank" rel="nofollow noopener">ショップで確認</a></td>
+                      <td>{it.price}円</td>
+                      <td>{it.pointRate}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )}
+          {lists.yahoo.length > 0 && (
+            <>
+              <h2>Yahoo</h2>
+              <table>
+                <thead>
+                  <tr><th>ショップ</th><th>価格</th><th>ポイント倍率</th></tr>
+                </thead>
+                <tbody>
+                  {lists.yahoo.map(it => (
+                    <tr>
+                      <td>{it.shopName} <a href={it.itemUrl} target="_blank" rel="nofollow noopener">ショップで確認</a></td>
+                      <td>{it.price}円</td>
+                      <td>{it.pointRate}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )}
           <p class="small">価格・在庫は常に変動します。購入前にリンク先で最新情報をご確認ください。</p>
         </>
       )}

--- a/src/pages/prices/index.astro
+++ b/src/pages/prices/index.astro
@@ -3,6 +3,7 @@ import "../../styles/global.css";
 import data from "../../data/prices/today.json";
 import skus from "../../data/skus.json";
 const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
+const sourceLabels = { rakuten: 'Rakuten', yahoo: 'Yahoo' };
 ---
 <html lang="ja">
   <head>
@@ -18,11 +19,13 @@ const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
       <p class="small">対象カテゴリから毎日、自動で候補を抽出し、価格とポイント相当を目安に並べ替えています。</p>
       <p class="small">表示価格は取得時点の参考値です。購入前に必ずリンク先の最新情報をご確認ください。</p>
       <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
+      <p class="small">Rakuten: {data.sourceStatus?.rakuten ?? 'n/a'} / Yahoo: {data.sourceStatus?.yahoo ?? 'n/a'}</p>
       <ul>
         {data.items.map(it => (
           <li>
             <a href={`prices/${it.skuId}/`}>{skuMap[it.skuId]?.q ?? it.skuId}</a>
-            : {it.bestPrice}円 ({it.bestShop})
+            : {it.bestPrice ?? '情報なし'}{it.bestPrice && '円'}{it.bestShop && ` (${it.bestShop})`}
+            {it.bestSource && <span class="small">[{sourceLabels[it.bestSource]}]</span>}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- fetch Yahoo Shopping prices with retry/backoff and snapshot fallback
- merge Rakuten and Yahoo results with source status and best-price selection
- show source badges and per-shop sections on prices pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd506284cc8326ad7e9a87e1c1dede