### PR TITLE
fix price history chart path and data handling

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -50,18 +50,22 @@ export function getStaticPaths() {
           </table>
           <p class="small">価格・在庫は常に変動します。購入前にリンク先で最新情報をご確認ください。</p>
           <h2>価格推移 (30日)</h2>
-          <canvas id="chart" width="600" height="200"></canvas>
+          <canvas id="chart" width="600" height="200" data-sku={sku}></canvas>
           <p id="chart-msg" class="small"></p>
           <p class="small">過去データはAPI仕様・収集失敗で欠損する場合があります。</p>
           <script>
-            const sku = {JSON.stringify(sku)};
-            fetch(`data/price-history/${sku}.json`).then(r => r.json()).then(hist => {
-              if (!Array.isArray(hist) || hist.length < 2) {
-                document.getElementById('chart-msg').textContent = 'データ少';
+            const canvas = document.getElementById('chart');
+            const sku = canvas.dataset.sku;
+            const msg = document.getElementById('chart-msg');
+            const base = document.baseURI;
+            fetch(new URL(`data/price-history/${sku}.json`, base)).then(r => r.json()).then(hist => {
+              const list = Array.isArray(hist) ? hist : Object.values(hist).find(Array.isArray) || [];
+              if (list.length < 2) {
+                canvas.style.display = 'none';
+                msg.textContent = 'データ少';
                 return;
               }
-              const data = hist.slice(-30);
-              const canvas = document.getElementById('chart');
+              const data = list.slice(-30);
               const ctx = canvas.getContext('2d');
               const prices = data.map(d => d.price);
               const min = Math.min(...prices);
@@ -76,7 +80,8 @@ export function getStaticPaths() {
               ctx.strokeStyle = '#0070f3';
               ctx.stroke();
             }).catch(() => {
-              document.getElementById('chart-msg').textContent = 'データ少';
+              canvas.style.display = 'none';
+              msg.textContent = 'データ少';
             });
           </script>
         </>


### PR DESCRIPTION
## Summary
- fetch price history using BASE_URL-resolved path and support array or object responses
- hide chart with message when history data has fewer than two points

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd5cbe29108326b1dafc719e766986