### PR TITLE
ci: skip pages workflow on history commits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   test-build:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: test-build
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +29,7 @@ jobs:
 
   deploy:
     needs: test-build
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/pipelines/prices-rakuten.mjs
+++ b/pipelines/prices-rakuten.mjs
@@ -10,6 +10,7 @@ const historyDir = path.join(rootDir, 'data', 'price-history');
 const publicHistoryDir = path.join(rootDir, 'public', 'data', 'price-history');
 
 const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Tokyo' });
+export const HISTORY_COMMIT_MESSAGE = 'chore(history): update prices [skip ci]';
 
 async function writeHistory(items, { force = false } = {}) {
   try {

--- a/pipelines/run-all.mjs
+++ b/pipelines/run-all.mjs
@@ -1,14 +1,13 @@
-import { fileURLToPath } from 'url';
-import path from 'path';
 import { exec as execCb } from 'child_process';
 import { promisify } from 'util';
+import { run as runRss } from './rss.mjs';
+import { run as runPrices, HISTORY_COMMIT_MESSAGE } from './prices-rakuten.mjs';
 const exec = promisify(execCb);
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function main(){
   const tasks = [
-    import(path.join(__dirname, 'rss.mjs')).then(m => m.run()),
-    import(path.join(__dirname, 'prices-rakuten.mjs')).then(m => m.run()),
+    runRss(),
+    runPrices(),
   ];
   const results = await Promise.allSettled(tasks);
   let hasFailure = false;
@@ -28,7 +27,7 @@ async function main(){
     await exec('git add data public src/data/prices/today.json');
     const { stdout } = await exec('git status --short data public src/data/prices/today.json');
     if (stdout.trim()) {
-      await exec('git commit -m "chore(history): update prices [skip ci]"');
+      await exec(`git commit -m "${HISTORY_COMMIT_MESSAGE}"`);
       await exec('git push');
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- centralize history commit message with `[skip ci]`
- skip build/deploy jobs when commit message contains `[skip ci]`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6fce2d088326a88eb1d7107f1aee