### PR TITLE
文言の更新：なんでも計算室＆お得チェッカー

### DIFF
--- a/src/pages/calculators.astro
+++ b/src/pages/calculators.astro
@@ -6,12 +6,12 @@ import "../styles/global.css";
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <base href={import.meta.env.BASE_URL} />
-    <title>かんたん計算室</title>
+    <title>なんでも計算室</title>
   </head>
   <body>
     <div class="wrap">
       <a href="./" class="small">← トップ</a>
-      <h1>かんたん計算室</h1>
+      <h1>なんでも計算室</h1>
       <div class="grid">
 
         <div class="card">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,21 +3,21 @@ import "../styles/global.css";
 const tools = [
   {
     href: "calculators/",
-    title: "かんたん計算室＆お得チェッカー",
-    desc: "いつでも開けるシンプル計算室",
+    title: "なんでも計算室",
+    desc: "シンプルな計算機がたくさん",
     cta: "計算する",
   },
   {
     href: "deals/",
     title: "今日のセールまとめ",
-    desc: "セール・割引情報を毎日自動で収集（公式ソースのみ）",
+    desc: "セール・割引情報を毎日更新",
     cta: "今日のお得を見る",
   },
   {
     href: "prices/",
     title: "今日の最安“候補”",
-    desc: "楽天市場の価格トラッカー（取得時点の参考価格）",
-    cta: "開く",
+    desc: "楽天市場の価格トラッカー",
+    cta: "今日の最安を探す",
   },
 ];
 ---
@@ -26,11 +26,11 @@ const tools = [
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <base href={import.meta.env.BASE_URL} />
-    <title>かんたん計算室＆お得チェッカー</title>
+    <title>なんでも計算室＆お得チェッカー</title>
   </head>
   <body>
     <div class="wrap">
-      <h1>かんたん計算室＆お得チェッカー</h1>
+      <h1>なんでも計算室＆お得チェッカー</h1>
       <p class="small">
         よく使う計算と今日のお得をまとめてチェック。
       </p>


### PR DESCRIPTION
## Summary
- トップページのタイトルや説明文を「なんでも計算室」にあわせて更新
- 各カードの説明文と価格トラッカーのボタン文言を調整
- 計算ページのタイトルを「なんでも計算室」に変更

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdad91fbd4832688bfda6c25c0bfa7