### PR TITLE
refactor: fetch price data via BASE_URL with fallback

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -1,13 +1,21 @@
 ---
 import "../../styles/global.css";
-import fs from "fs/promises";
-import path from "path";
 import skus from "../../data/skus.json";
-const raw = await fs.readFile(path.join(process.cwd(), "public", "data", "prices", "today.json"), "utf-8");
-const data = JSON.parse(raw);
+
+let data;
+try {
+  const url = new URL(
+    import.meta.env.BASE_URL + "data/prices/today.json",
+    Astro.site
+  );
+  const res = await fetch(url);
+  if (res.ok) {
+    data = await res.json();
+  }
+} catch {}
 const { sku } = Astro.params;
 const skuInfo = skus.find(s => s.id === sku);
-const priceInfo = data.items.find(i => i.skuId === sku);
+const priceInfo = data?.items?.find(i => i.skuId === sku);
 
 export function getStaticPaths() {
   return skus.map(s => ({ params: { sku: s.id } }));
@@ -25,7 +33,11 @@ export function getStaticPaths() {
         <a href="./" class="small">← トップ</a>
       <h1>{skuInfo ? skuInfo.q : sku} – 価格一覧</h1>
       <p>ショップ別の価格を一覧しています。並び順は目安（価格・ポイント相当）です。</p>
-      <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
+      <p class="small">
+        {data
+          ? `取得日時: ${new Date(data.updatedAt).toLocaleString('ja-JP')}`
+          : 'データ少'}
+      </p>
       {skuInfo && (
         <div>
           <h2>仕様</h2>
@@ -35,7 +47,7 @@ export function getStaticPaths() {
           </ul>
         </div>
       )}
-      {priceInfo && (
+      {priceInfo ? (
         <>
           <table>
             <thead>
@@ -60,7 +72,7 @@ export function getStaticPaths() {
             const canvas = document.getElementById('chart');
             const sku = canvas.dataset.sku;
             const msg = document.getElementById('chart-msg');
-            const base = document.baseURI;
+            const base = "{import.meta.env.BASE_URL}";
             fetch(`${base}data/price-history/${sku}.json?t=${Date.now()}`).then(r => r.json()).then(hist => {
               const list = Array.isArray(hist) ? hist : Object.values(hist).find(Array.isArray) || [];
               const data = list.filter(d => Number.isFinite(d.price)).slice(-30);
@@ -88,6 +100,8 @@ export function getStaticPaths() {
             });
           </script>
         </>
+      ) : (
+        <p>データ少</p>
       )}
     </div>
   </body>

--- a/src/pages/prices/index.astro
+++ b/src/pages/prices/index.astro
@@ -1,10 +1,18 @@
 ---
 import "../../styles/global.css";
-import fs from "fs/promises";
-import path from "path";
 import skus from "../../data/skus.json";
-const raw = await fs.readFile(path.join(process.cwd(), "public", "data", "prices", "today.json"), "utf-8");
-const data = JSON.parse(raw);
+
+let data;
+try {
+  const url = new URL(
+    import.meta.env.BASE_URL + "data/prices/today.json",
+    Astro.site
+  );
+  const res = await fetch(url);
+  if (res.ok) {
+    data = await res.json();
+  }
+} catch {}
 const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
 ---
 <html lang="ja">
@@ -20,15 +28,21 @@ const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
       <h1>今日の最安“候補”</h1>
       <p class="small">対象カテゴリから毎日、自動で候補を抽出し、価格とポイント相当を目安に並べ替えています。</p>
       <p class="small">表示価格は取得時点の参考値です。購入前に必ずリンク先の最新情報をご確認ください。</p>
-      <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
-      <ul>
-        {data.items.map(it => (
-          <li>
-            <a href={`prices/${it.skuId}/`}>{skuMap[it.skuId]?.q ?? it.skuId}</a>
-            : {it.bestPrice}円 ({it.bestShop})
-          </li>
-        ))}
-      </ul>
+      {data ? (
+        <>
+          <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
+          <ul>
+            {data.items.map(it => (
+              <li>
+                <a href={`prices/${it.skuId}/`}>{skuMap[it.skuId]?.q ?? it.skuId}</a>
+                : {it.bestPrice}円 ({it.bestShop})
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <p>データ少</p>
+      )}
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch price data from BASE_URL for price pages
- handle fetch failures with graceful fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb55db97c83268c83f81baae03c38