### PR TITLE
feat(pipelines): improve Rakuten price pipeline observability

### DIFF
--- a/public/data/prices/today.json
+++ b/public/data/prices/today.json
@@ -1,5 +1,8 @@
 {
   "updatedAt": "1970-01-01T00:00:00.000Z",
+  "sourceStatus": {
+    "rakuten": "ok"
+  },
   "items": [
     {
       "skuId": "ssd_1tb",


### PR DESCRIPTION
## Summary
- log RAKUTEN_APP_ID detection and price validation results
- add rakuten sourceStatus to today.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb6a0a1788326a4de04ae80f46c7e