### PR TITLE
chore: pass Rakuten app ID to pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
       - run: npm ci
       - name: Run pipelines (rss, prices-rakuten)
         run: npm run pipeline
+        env:
+          RAKUTEN_APP_ID: ${{ secrets.RAKUTEN_APP_ID }}
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with: { path: "dist" }


### PR DESCRIPTION
## Summary
- GitHub ActionsのパイプラインステップにRAKUTEN_APP_IDを渡すよう修正

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbc35c57c83268bd926f2e3a02c7d