### PR TITLE
feat: show absolute and recommended lowest prices

### DIFF
--- a/public/data/prices/today.json
+++ b/public/data/prices/today.json
@@ -8,6 +8,10 @@
       "skuId": "ssd_1tb",
       "bestPrice": 10000,
       "bestShop": "Dummy Shop",
+      "bestRecommended": {
+        "price": 10000,
+        "shop": "Dummy Shop"
+      },
       "list": [
         {
           "title": "SanDisk 1TB SSD",
@@ -24,6 +28,10 @@
       "skuId": "sd_128",
       "bestPrice": 2000,
       "bestShop": "Example Store",
+      "bestRecommended": {
+        "price": 2000,
+        "shop": "Example Store"
+      },
       "list": [
         {
           "title": "SanDisk 128GB SD",

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -26,9 +26,10 @@ const bestToday = list.length
   : null;
 let bestRecommended;
 if (list.length && skuInfo?.brandHints?.length) {
-  const cand = list.filter(it =>
-    skuInfo.brandHints.some(b => it.title?.toLowerCase().includes(b.toLowerCase()))
-  );
+  const cand = list.filter(it => {
+    const title = it.title?.toLowerCase() ?? '';
+    return skuInfo.brandHints.some(b => title.includes(b.toLowerCase()));
+  });
   if (cand.length) {
     bestRecommended = cand.reduce((min, it) => (it.price < min.price ? it : min), cand[0]);
   }

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -20,6 +20,28 @@ const updatedJst = data?.updatedAt
   ? new Date(data.updatedAt).toLocaleDateString('en-CA', { timeZone: 'Asia/Tokyo' })
   : null;
 
+const list = priceInfo?.list ?? [];
+const bestToday = list.length
+  ? list.reduce((min, it) => (it.price < min.price ? it : min), list[0])
+  : null;
+let bestRecommended;
+if (list.length && skuInfo?.brandHints?.length) {
+  const cand = list.filter(it =>
+    skuInfo.brandHints.some(b => it.title?.toLowerCase().includes(b.toLowerCase()))
+  );
+  if (cand.length) {
+    bestRecommended = cand.reduce((min, it) => (it.price < min.price ? it : min), cand[0]);
+  }
+}
+function formatPrice(it) {
+  if (!it) return '';
+  if (it.pointRate) {
+    const eff = Math.round(it.price * (100 - it.pointRate) / 100);
+    return `${it.price}円（ポイント${it.pointRate}%で実質${eff}円）`;
+  }
+  return `${it.price}円`;
+}
+
 export function getStaticPaths() {
   return skus.map(s => ({ params: { sku: s.id } }));
 }
@@ -52,6 +74,20 @@ export function getStaticPaths() {
       )}
       {priceInfo ? (
         <>
+          <div>
+            <h2>最安情報</h2>
+            <ul>
+              <li>今日の最安: {bestToday ? `${formatPrice(bestToday)} (${bestToday.shopName})` : 'データ少'}</li>
+              {skuInfo?.brandHints?.length && (
+                <li>
+                  推奨最安（ブランド一致優先）:
+                  {bestRecommended
+                    ? `${formatPrice(bestRecommended)} (${bestRecommended.shopName})`
+                    : '該当なし'}
+                </li>
+              )}
+            </ul>
+          </div>
           <table>
             <thead>
               <tr><th>ショップ</th><th>価格</th><th>ポイント倍率</th></tr>


### PR DESCRIPTION
## Summary
- display absolute lowest price on SKU page
- show brand-matched recommended price separately
- add bestRecommended field in today.json data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf9a1a1a848326886a6adce6eeabd8