### PR TITLE
chore: refine CI and deploy workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
-  push:
-    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,9 @@ on:
     branches: [ main ]
   schedule:
     - cron: "0 18 * * *"  # 03:00 JST
-  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- run CI workflow only on PRs
- deploy workflow handles only main pushes and scheduled runs with minimal permissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfa4329e80832692a91c8bacd88e0d