### PR TITLE
ci: cancel duplicate deploy runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 18 * * *"  # 03:00 JST
 
+concurrency:
+  group: "deploy-${{ github.ref }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
## Summary
- cancel in-progress deploy workflows on new pushes via concurrency group

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfa5544534832681729c63c67d85eb