### PR TITLE
fix: unify shopName field

### DIFF
--- a/public/data/prices/today.json
+++ b/public/data/prices/today.json
@@ -7,7 +7,6 @@
     {
       "skuId": "ssd_1tb",
       "bestPrice": 10000,
-      "bestShop": "Dummy Shop",
       "bestRecommended": {
         "price": 10000,
         "shopName": "Dummy Shop"
@@ -27,7 +26,6 @@
     {
       "skuId": "sd_128",
       "bestPrice": 2000,
-      "bestShop": "Example Store",
       "bestRecommended": {
         "price": 2000,
         "shopName": "Example Store"

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -25,6 +25,9 @@ const bestToday = list.length
   ? list.reduce((min, it) => (it.price < min.price ? it : min), list[0])
   : null;
 let bestRecommended = priceInfo?.bestRecommended ?? null;
+if (bestRecommended?.shop && !bestRecommended.shopName) {
+  bestRecommended = { ...bestRecommended, shopName: bestRecommended.shop };
+}
 if (!bestRecommended && list.length && skuInfo?.brandHints?.length) {
   const cand = list.filter(it =>
     skuInfo.brandHints.some(b => it.title?.toLowerCase().includes(b.toLowerCase()))


### PR DESCRIPTION
## Summary
- handle legacy `bestRecommended.shop` values by normalizing to `shopName`
- remove redundant `bestShop` entry from today.json

## Testing
- `npm test`
- `npm run build`
- `curl -I http://localhost:4321/prices/ssd_1tb/`


------
https://chatgpt.com/codex/tasks/task_e_68bfc16a688c83268c0aa0a40511c063