### PR TITLE
Refine brand hint title matching

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -26,9 +26,10 @@ const bestToday = list.length
   : null;
 let bestRecommended = priceInfo?.bestRecommended ?? null;
 if (!bestRecommended && list.length && skuInfo?.brandHints?.length) {
-  const cand = list.filter(it =>
-    skuInfo.brandHints.some(b => it.title?.toLowerCase().includes(b.toLowerCase()))
-  );
+  const cand = list.filter(it => {
+    const title = it.title?.toLowerCase() ?? '';
+    return skuInfo.brandHints.some(b => title.includes(b.toLowerCase()));
+  });
   if (cand.length) {
     bestRecommended = cand.reduce((min, it) => (it.price < min.price ? it : min), cand[0]);
   }


### PR DESCRIPTION
## Summary
- handle missing item titles when matching brand hints

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfc920cf488326b30d8b37de0eb890