### PR TITLE
feat: add Yahoo Shopping price pipeline

### DIFF
--- a/pipelines/prices-yahoo.mjs
+++ b/pipelines/prices-yahoo.mjs
@@ -1,0 +1,69 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs/promises';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.join(__dirname, '..');
+const skuPath = path.join(rootDir, 'src', 'data', 'skus.json');
+const outPath = path.join(rootDir, 'public', 'data', 'prices', 'today.yahoo.json');
+
+export async function run() {
+  const appId = process.env.YAHOO_APP_ID;
+  console.log(`[yahoo] appId ${appId ? 'detected' : 'missing'}`);
+  if (!appId) return;
+
+  let skus = [];
+  try {
+    const raw = await fs.readFile(skuPath, 'utf-8');
+    skus = JSON.parse(raw);
+  } catch (e) {
+    console.error('[yahoo] failed to read skus.json', e);
+    return;
+  }
+
+  const items = [];
+  for (const sku of skus) {
+    try {
+      const url = new URL('https://shopping.yahooapis.jp/ShoppingWebService/V3/itemSearch');
+      url.searchParams.set('appid', appId);
+      url.searchParams.set('query', sku.q);
+      url.searchParams.set('hits', '20');
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const data = await res.json();
+      const hits = data.hits || data.Items || data.items || [];
+      const list = hits.map(it => ({
+        title: it.name,
+        shopName: it.seller?.name,
+        itemUrl: it.url,
+        price: Number(it.price) || null,
+        pointRate: Number(it.point?.amount) || Number(it.point) || 0,
+        imageUrl: it.image?.small || it.image?.medium || it.image,
+        itemCode: it.code
+      })).filter(it => typeof it.price === 'number');
+      list.sort((a, b) => a.price - b.price);
+      const best = list[0];
+      items.push({ skuId: sku.id, bestPrice: best?.price ?? null, bestShop: best?.shopName ?? null, list });
+    } catch (e) {
+      console.error('[yahoo] sku failed', sku.id, e);
+      items.push({ skuId: sku.id, bestPrice: null, bestShop: null, list: [] });
+    }
+  }
+
+  const out = { updatedAt: new Date().toISOString(), items, sourceStatus: { yahoo: 'ok' } };
+  try {
+    await fs.mkdir(path.dirname(outPath), { recursive: true });
+    await fs.writeFile(outPath, JSON.stringify(out, null, 2));
+    console.log('[yahoo] wrote', outPath);
+    console.log(`[yahoo] items: ${items.length}`);
+  } catch (e) {
+    console.error('[yahoo] failed to write output', e);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().catch(e => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/pipelines/run-all.mjs
+++ b/pipelines/run-all.mjs
@@ -1,5 +1,6 @@
 import { run as runRss } from './rss.mjs';
 import { run as runPrices } from './prices-rakuten.mjs';
+import { run as runYahooPrices } from './prices-yahoo.mjs';
 
 async function runWithLog(name, fn) {
   console.log(`[pipeline] start ${name}`);
@@ -20,6 +21,11 @@ async function main(){
     tasks.push(runWithLog('prices-rakuten', runPrices));
   } else {
     console.log('[pipeline] skip prices-rakuten: RAKUTEN_APP_ID not set');
+  }
+  if (process.env.YAHOO_APP_ID) {
+    tasks.push(runWithLog('prices-yahoo', runYahooPrices));
+  } else {
+    console.log('[pipeline] skip prices-yahoo: YAHOO_APP_ID not set');
   }
   const results = await Promise.allSettled(tasks);
   let hasFailure = false;

--- a/public/data/prices/today.yahoo.json
+++ b/public/data/prices/today.yahoo.json
@@ -1,0 +1,22 @@
+{
+  "updatedAt": "1970-01-01T00:00:00.000Z",
+  "sourceStatus": { "yahoo": "ok" },
+  "items": [
+    {
+      "skuId": "ssd_1tb",
+      "bestPrice": 10000,
+      "bestShop": "Dummy Store",
+      "list": [
+        {
+          "title": "Sample 1TB SSD",
+          "shopName": "Dummy Store",
+          "itemUrl": "https://example.com/ssd",
+          "price": 10000,
+          "pointRate": 0,
+          "imageUrl": "https://example.com/ssd.jpg",
+          "itemCode": "dummy1"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Yahoo price pipeline using Yahoo Shopping API and output normalized data
- integrate Yahoo pipeline into run-all

## Testing
- `npm test`
- `node pipelines/prices-yahoo.mjs`
- `node pipelines/run-all.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68c02902672083268269c01b7e2ec293