### PR TITLE
Hide price section status badge for ok sources

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -177,7 +177,12 @@ export function getStaticPaths() {
           </div>
           {sections.map(sec => (
             <div class="price-section tab-content" data-tab={sec.key} style="display:none">
-              <h2>{sec.name} <span class={`badge ${sec.status}`}>{sec.status}</span></h2>
+              <h2>
+                {sec.name}
+                {sec.status !== 'ok' && (
+                  <span class={`badge ${sec.status}`}>{sec.status}</span>
+                )}
+              </h2>
               {sec.list.length ? (
                 <>
                   <button class="sort-toggle">実質価格順に切替</button>


### PR DESCRIPTION
## Summary
- hide status badge for a section if the price source status is `ok`
- only show badge for `partial` or `fail`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c534b3c9b08326a143711b1fe41be3