### PR TITLE
feat: warn on source issues for price sources

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -54,6 +54,10 @@ const sections = [
   { name: 'Rakuten', key: 'rakuten', list: rakutenList, status: data?.sourceStatus?.rakuten ?? 'fail', hasPoints: rakutenList.some(it => it.pointRate) },
   { name: 'Yahoo', key: 'yahoo', list: yahooList, status: data?.sourceStatus?.yahoo ?? 'fail', hasPoints: yahooList.some(it => it.pointRate) }
 ];
+const statusMessages = {
+  partial: 'このソースの一部データが取得できませんでした。表示は最新の取得分です。',
+  fail: 'このソースの取得に失敗しました。別ソースまたは前回データで表示しています。'
+};
 const bestToday = list.length
   ? list.reduce((min, it) => (it.price < min.price ? it : min), list[0])
   : null;
@@ -92,10 +96,7 @@ export function getStaticPaths() {
     <base href={import.meta.env.BASE_URL} />
     <title>{skuInfo ? skuInfo.q : sku} – 価格一覧</title>
     <style>
-      .badge{display:inline-block;padding:2px 6px;border-radius:4px;font-size:12px;color:#fff}
-      .ok{background:#16a34a}
-      .partial{background:#d97706}
-      .fail{background:#dc2626}
+      .warn-icon{font-size:0.9em;margin-left:4px;cursor:help;vertical-align:middle}
       .tabs{display:flex;gap:4px;margin:1em 0}
       .tabs button{padding:4px 8px;border:1px solid #ccc;background:#f3f3f3;cursor:pointer}
       .tabs button.active{background:#ddd}
@@ -177,8 +178,13 @@ export function getStaticPaths() {
             )}
           </div>
           {sections.map(sec => (
-            <div class="price-section tab-content" data-tab={sec.key} style="display:none">
-              <h2>{sec.name} <span class={`badge ${sec.status}`}>{sec.status}</span></h2>
+            <div class="price-section tab-content" data-tab={sec.key} data-source-status={sec.status} style="display:none">
+              <h2>
+                {sec.name}
+                {sec.status !== 'ok' && (
+                  <span class="warn-icon" aria-label={statusMessages[sec.status]} title={statusMessages[sec.status]}>⚠️</span>
+                )}
+              </h2>
               {sec.list.length ? (
                 <>
                   {sec.hasPoints && <button class="sort-toggle">実質価格順に切替</button>}


### PR DESCRIPTION
## Summary
- show warning icon and tooltip when Rakuten/Yahoo data is partial or failed
- mark section wrappers with data-source-status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c56b1937508326a45d5b0af44598d6