### PR TITLE
Clarify effective price label

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -153,7 +153,7 @@ export function getStaticPaths() {
                       <th>ショップ</th>
                       <th>価格</th>
                       <th>ポイント</th>
-                      <th>実質価格<br/><span class="small">（ポイント反映）</span></th>
+                      <th>実質価格<br/><span class="small">（ポイント込み）</span></th>
                     </tr>
                   </thead>
                   <tbody>
@@ -193,7 +193,7 @@ export function getStaticPaths() {
                         <th>ショップ</th>
                         <th>価格</th>
                         <th>ポイント</th>
-                        <th>実質価格<br/><span class="small">（ポイント反映）</span></th>
+                        <th>実質価格<br/><span class="small">（ポイント込み）</span></th>
                       </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
## Summary
- change price table label to use "実質価格（ポイント込み）" wording

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c654bd692c83269adcf164feb022a8