### PR TITLE
docs: remove test comment from policy

### DIFF
--- a/policy.md
+++ b/policy.md
@@ -1,5 +1,4 @@
 <!-- Dummy comment for PR testing -->
-<!-- CI/CD flow test comment -->
 # 自動化工場プロジェクト方針（v0.3）
 > 目的：**完全放置で回る“小さな収益装置”を量産**し、合算で**月15万円**を目指す。  
 > 役割分担：**ちゃっくん＝戦略・設計 / Codex＝実装**（`codex-playbook-fixed.md` 準拠）。  


### PR DESCRIPTION
## Summary
- remove unused CI/CD flow test comment from policy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f41362f08326afbefe54598ad160