### PR TITLE
Add affiliate policy page

### DIFF
--- a/src/pages/about/affiliate.astro
+++ b/src/pages/about/affiliate.astro
@@ -1,0 +1,23 @@
+---
+import "../../styles/global.css";
+import Footer from "../../components/Footer.astro";
+---
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <base href={import.meta.env.BASE_URL} />
+    <title>アフィリエイトについて</title>
+  </head>
+  <body>
+    <div class="wrap">
+      <a href="./" class="small">← トップ</a>
+      <h1>アフィリエイトについて</h1>
+      <p>一部のリンクはアフィリエイトリンクを含みます。購入により、運営に紹介料が支払われる場合があります。</p>
+      <p>紹介料は商品価格やお客様の負担に影響しません。</p>
+      <p>本サイトの掲載順・評価は、取得時点の情報（価格・在庫・仕様）と独自ルール（ノイズ除外など）に基づきます。</p>
+      <p>購入の最終判断は、必ずリンク先の最新情報をご確認ください。</p>
+    </div>
+    <Footer />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add an /about/affiliate page that outlines the site's affiliate disclosure
- reuse the global layout styling and base href configuration for consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c914e3e18c8326aa2eb5b7bcd61e87