### PR TITLE
Use setup-chromium in Lighthouse workflows

### DIFF
--- a/.github/workflows/qa-lighthouse-nightly.yml
+++ b/.github/workflows/qa-lighthouse-nightly.yml
@@ -48,10 +48,23 @@ jobs:
         env:
           NPM_CONFIG_CACHE: ~/.npm
 
-      - name: Build site and install Chromium
-        run: npm run pretest:a11y
+      - name: Build site and prepare Lighthouse bundle
+        run: |
+          npm run build
+          node scripts/prepare-lhci-dist.mjs
         env:
           NPM_CONFIG_CACHE: ~/.npm
+
+      - name: Install Chromium via Playwright (disabled on CI)
+        if: ${{ runner.os == 'Linux' && false }}
+        run: node scripts/setup-playwright.mjs
+
+      - name: Setup Chromium
+        id: setup-chromium
+        uses: browser-actions/setup-chromium@v1
+
+      - name: Set CHROME_PATH
+        run: echo "CHROME_PATH=${{ steps.setup-chromium.outputs.chromium-path }}" >> $GITHUB_ENV
 
       - name: Run Lighthouse accessibility checks
         run: npm run test:a11y

--- a/.github/workflows/qa-lighthouse-pr.yml
+++ b/.github/workflows/qa-lighthouse-pr.yml
@@ -51,10 +51,23 @@ jobs:
         env:
           NPM_CONFIG_CACHE: ~/.npm
 
-      - name: Build site and install Chromium
-        run: npm run pretest:a11y
+      - name: Build site and prepare Lighthouse bundle
+        run: |
+          npm run build
+          node scripts/prepare-lhci-dist.mjs
         env:
           NPM_CONFIG_CACHE: ~/.npm
+
+      - name: Install Chromium via Playwright (disabled on CI)
+        if: ${{ runner.os == 'Linux' && false }}
+        run: node scripts/setup-playwright.mjs
+
+      - name: Setup Chromium
+        id: setup-chromium
+        uses: browser-actions/setup-chromium@v1
+
+      - name: Set CHROME_PATH
+        run: echo "CHROME_PATH=${{ steps.setup-chromium.outputs.chromium-path }}" >> $GITHUB_ENV
 
       - name: Select Lighthouse config
         id: lighthouse-config

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# calc-hub
+
+## アクセシビリティチェックの実行手順
+
+- ローカル開発では `npm run pretest:a11y` を実行すると、ビルドと Lighthouse 用の準備に加えて Playwright 経由で Chromium が取得されます。続けて `npm run test:a11y` を実行してください。
+- GitHub Actions 上では `browser-actions/setup-chromium` が Chromium を提供するため、Playwright からのダウンロードは行われません。

--- a/scripts/run-lhci.mjs
+++ b/scripts/run-lhci.mjs
@@ -30,15 +30,25 @@ function runNpx(args, options = {}) {
   return result;
 }
 
-const { chromium } = await import('playwright');
-const chromePath = chromium.executablePath();
+let chromePath = process.env.CHROME_PATH;
+let chromeSource = 'CHROME_PATH environment variable';
 
 if (!chromePath) {
-  console.error('Could not determine the Chromium executable path from Playwright.');
+  try {
+    const { chromium } = await import('playwright');
+    chromePath = chromium.executablePath();
+    chromeSource = 'Playwright';
+  } catch (error) {
+    console.error('Failed to resolve Chromium via Playwright:', error);
+  }
+}
+
+if (!chromePath) {
+  console.error('Could not determine the Chromium executable path.');
   process.exit(1);
 }
 
-console.log(`Using Chromium executable: ${chromePath}`);
+console.log(`Using Chromium executable (${chromeSource}): ${chromePath}`);
 
 const configPath = process.env.LHCI_CONFIG || '.lighthouserc.json';
 const allowAssertFailure = process.env.ALLOW_ASSERT_FAILURE === '1';


### PR DESCRIPTION
## Summary
- disable the Playwright-driven Chromium download in CI and provision the browser via `browser-actions/setup-chromium`
- let the LHCI runner prefer `CHROME_PATH` and keep Playwright as a fallback for local runs
- document how local developers can fetch Chromium with `npm run pretest:a11y`

## Testing
- `npm ci`
- `npm run build`
- `ALLOW_ASSERT_FAILURE=1 npm run test:a11y`


------
https://chatgpt.com/codex/tasks/task_e_68ca48f554588326b1ed2107bf214fdb