### PR TITLE
Add diff-based Lighthouse URL selection

### DIFF
--- a/scripts/generate-lhci-urls.mjs
+++ b/scripts/generate-lhci-urls.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { execSync } from 'node:child_process';
+import { dirname, extname, isAbsolute, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(currentDir, '..');
+
+const DOCUMENTATION_EXTENSIONS = new Set(['.md', '.markdown', '.txt']);
+
+function loadDefaultUrls(config) {
+  return config?.ci?.collect?.url ?? [];
+}
+
+async function readConfig(configPath) {
+  const content = await readFile(configPath, 'utf8');
+  return JSON.parse(content);
+}
+
+function astroPathToUrl(relativePath) {
+  if (!relativePath.endsWith('.astro')) {
+    return null;
+  }
+
+  if (/[\[{]/.test(relativePath)) {
+    return null;
+  }
+
+  const withoutExtension = relativePath.replace(/\.astro$/, '');
+
+  if (withoutExtension === 'index') {
+    return 'index.html';
+  }
+
+  if (withoutExtension.endsWith('/index')) {
+    const base = withoutExtension.replace(/\/index$/, '');
+    return base ? `${base}/index.html` : 'index.html';
+  }
+
+  return `${withoutExtension}/index.html`;
+}
+
+function collectChangedFiles(baseRef) {
+  let diffOutput = '';
+
+  const options = { cwd: projectRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] };
+
+  if (process.env.LHCI_DIFF_RANGE) {
+    try {
+      diffOutput = execSync(`git diff --name-only ${process.env.LHCI_DIFF_RANGE}`, options);
+    } catch (error) {
+      console.warn(`Failed to run git diff for LHCI_DIFF_RANGE: ${error.message}`);
+      return [];
+    }
+
+    return diffOutput.split('\n').map((line) => line.trim()).filter(Boolean);
+  }
+
+  const candidates = [baseRef, 'main', 'master'];
+  const tried = new Set();
+  let baseCommit = null;
+
+  for (const candidate of candidates) {
+    if (!candidate || tried.has(candidate)) {
+      continue;
+    }
+
+    tried.add(candidate);
+
+    try {
+      baseCommit = execSync(`git merge-base HEAD ${candidate}`, options).trim();
+      if (baseCommit) {
+        break;
+      }
+    } catch (error) {
+      // Try the next candidate.
+    }
+  }
+
+  if (baseCommit) {
+    diffOutput = execSync(`git diff --name-only ${baseCommit}`, options);
+    return diffOutput.split('\n').map((line) => line.trim()).filter(Boolean);
+  }
+
+  try {
+    diffOutput = execSync('git diff --name-only HEAD^', options);
+  } catch (error) {
+    console.warn('Failed to determine git diff range; falling back to default URLs.');
+    return [];
+  }
+
+  return diffOutput.split('\n').map((line) => line.trim()).filter(Boolean);
+}
+
+function shouldIgnoreFile(file) {
+  const ext = extname(file).toLowerCase();
+
+  if (DOCUMENTATION_EXTENSIONS.has(ext)) {
+    return true;
+  }
+
+  if (file.startsWith('.github/')) {
+    return true;
+  }
+
+  return false;
+}
+
+export async function generateLhciUrls() {
+  const configEnvPath = process.env.LHCI_CONFIG;
+  const configPath = configEnvPath
+    ? isAbsolute(configEnvPath)
+      ? configEnvPath
+      : join(projectRoot, configEnvPath)
+    : join(projectRoot, '.lighthouserc.json');
+  let config;
+
+  try {
+    config = await readConfig(configPath);
+  } catch (error) {
+    console.warn(`Failed to read LHCI config at ${configPath}: ${error.message}`);
+    config = {};
+  }
+
+  const defaultUrls = loadDefaultUrls(config);
+
+  const baseRef = process.env.LHCI_BASE_REF || 'origin/main';
+  const changedFiles = collectChangedFiles(baseRef);
+
+  if (changedFiles.length === 0) {
+    return defaultUrls;
+  }
+
+  const urls = new Set();
+  let fallbackRequired = false;
+
+  for (const file of changedFiles) {
+    if (shouldIgnoreFile(file)) {
+      continue;
+    }
+
+    if (file.startsWith('src/pages/')) {
+      const relative = file.slice('src/pages/'.length);
+      const url = astroPathToUrl(relative);
+      if (url) {
+        urls.add(url);
+        continue;
+      }
+
+      fallbackRequired = true;
+      break;
+    }
+
+    if (file.startsWith('public/')) {
+      const relative = file.slice('public/'.length);
+      if (relative.endsWith('.html')) {
+        urls.add(relative);
+        continue;
+      }
+
+      fallbackRequired = true;
+      break;
+    }
+
+    fallbackRequired = true;
+    break;
+  }
+
+  if (fallbackRequired || urls.size === 0) {
+    return defaultUrls;
+  }
+
+  return [...urls];
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const urls = await generateLhciUrls();
+  for (const url of urls) {
+    console.log(url);
+  }
+}

--- a/scripts/generate-lhci-urls.mjs
+++ b/scripts/generate-lhci-urls.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { execSync } from 'node:child_process';
 import { dirname, extname, isAbsolute, join } from 'node:path';
@@ -136,6 +137,10 @@ export async function generateLhciUrls() {
   let fallbackRequired = false;
 
   for (const file of changedFiles) {
+    if (!existsSync(join(projectRoot, file))) {
+      continue;
+    }
+
     if (shouldIgnoreFile(file)) {
       continue;
     }

--- a/scripts/run-lhci.mjs
+++ b/scripts/run-lhci.mjs
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { rmSync } from 'node:fs';
 
+import { generateLhciUrls } from './generate-lhci-urls.mjs';
+
 const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(currentDir, '..');
@@ -58,7 +60,22 @@ const env = {
   CHROME_PATH: chromePath,
 };
 
-runNpx(['lhci', 'collect', `--config=${configPath}`], {
+const urls = await generateLhciUrls();
+
+if (urls.length === 0) {
+  console.warn('No URLs resolved for LHCI collect; falling back to configuration defaults.');
+}
+
+if (urls.length > 0) {
+  console.log('LHCI will collect reports for the following URLs:');
+  for (const url of urls) {
+    console.log(`  - ${url}`);
+  }
+}
+
+const collectArgs = ['lhci', 'collect', `--config=${configPath}`, ...urls.map((url) => `--url=${url}`)];
+
+runNpx(collectArgs, {
   env,
 });
 


### PR DESCRIPTION
## Summary
- add a script that derives Lighthouse target URLs from the git diff and falls back to the default list when necessary
- update the LHCI runner to call the new script, log the selected URLs, and pass them to `lhci collect`

## Testing
- npm run test:a11y *(fails: accessibility assertion for calculators page already below threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6fa43d8883268c3161c44c271b92