### PR TITLE
feat: improve focus visibility and external link labelling

### DIFF
--- a/src/pages/deals.astro
+++ b/src/pages/deals.astro
@@ -19,7 +19,13 @@ function fmt(d){ try{ return new Date(d).toLocaleString(); }catch{ return d; } }
       <p class="small">主要サイトの公式情報から毎日自動で集めています。ノイズ（求人・PR等）は除外。</p>
       <div class="grid" style="margin-top:8px">
         {items.map((it) => (
-          <a class="card" href={it.link} target="_blank" rel="nofollow noopener">
+          <a
+            class="card"
+            href={it.link}
+            target="_blank"
+            rel="nofollow noopener"
+            title={`${it.source}で詳細を確認できます（新しいタブが開きます）`}
+          >
             <h2 style="margin:0 0 6px 0">{it.title}</h2>
             <p class="small" style="margin:0 0 6px 0">{it.source} / {fmt(it.date)}</p>
             {it.description && <p style="margin:0">{it.description}</p>}

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -82,6 +82,13 @@ function formatSummary(it) {
   return formatPrice(it);
 }
 
+function getShopLinkDescription(name) {
+  if (!name) {
+    return 'ショップで商品の詳細を確認できます（新しいタブで開きます）';
+  }
+  return `${name}で商品の詳細を確認できます（新しいタブで開きます）`;
+}
+
 export function getStaticPaths() {
   return skus.map(s => ({ params: { sku: s.id } }));
 }
@@ -154,7 +161,19 @@ export function getStaticPaths() {
                       return (
                         <tr data-price={it.price} data-eff={eff}>
                           <td>{it.store}</td>
-                          <td>{it.shopName} <a href={it.itemUrl} target="_blank" rel="nofollow noopener">ショップで確認</a></td>
+                          <td>
+                            {it.shopName}
+                            <a
+                              href={it.itemUrl}
+                              target="_blank"
+                              rel="nofollow noopener"
+                              title={getShopLinkDescription(it.shopName)}
+                              aria-label={getShopLinkDescription(it.shopName)}
+                            >
+                              ショップで確認
+                              <span aria-hidden="true" class="external-link-icon">↗</span>
+                            </a>
+                          </td>
                           <td>{formatPrice(it)}</td>
                           <td>{it.pointRate ? `${it.pointRate}%` : '-'}</td>
                           <td>{eff}円</td>
@@ -193,7 +212,19 @@ export function getStaticPaths() {
                         const eff = Math.floor(it.price * (100 - (it.pointRate ?? 0)) / 100);
                         return (
                           <tr data-price={it.price} data-eff={eff}>
-                            <td>{it.shopName} <a href={it.itemUrl} target="_blank" rel="nofollow noopener">ショップで確認</a></td>
+                            <td>
+                              {it.shopName}
+                              <a
+                                href={it.itemUrl}
+                                target="_blank"
+                                rel="nofollow noopener"
+                                title={getShopLinkDescription(it.shopName)}
+                                aria-label={getShopLinkDescription(it.shopName)}
+                              >
+                                ショップで確認
+                                <span aria-hidden="true" class="external-link-icon">↗</span>
+                              </a>
+                            </td>
                             <td>{formatPrice(it)}</td>
                             <td>{it.pointRate ? `${it.pointRate}%` : '-'}</td>
                             <td>{eff}円</td>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -41,6 +41,11 @@ body {
   font: 16px/1.6 system-ui, Segoe UI, Meiryo, sans-serif;
 }
 
+:focus-visible {
+  outline: 2px solid var(--link-hover);
+  outline-offset: 2px;
+}
+
 a {
   color: var(--link);
   text-decoration: underline;
@@ -56,11 +61,6 @@ a:focus-visible {
 
 a:active {
   color: var(--link-active);
-}
-
-a:focus-visible {
-  outline: 2px solid var(--link-hover);
-  outline-offset: 2px;
 }
 
 .wrap {
@@ -107,11 +107,6 @@ a:focus-visible {
   color: var(--fg-inverted);
 }
 
-.btn:focus-visible {
-  outline: 2px solid var(--link-hover);
-  outline-offset: 2px;
-}
-
 h1,
 h2 {
   line-height: 1.2;
@@ -138,7 +133,7 @@ input:focus-visible,
 select:focus-visible {
   border-color: var(--link);
   outline: 2px solid var(--link);
-  outline-offset: 1px;
+  outline-offset: 2px;
 }
 
 label {
@@ -261,6 +256,13 @@ label {
 .sort-toggle:focus-visible {
   outline: 2px solid var(--link-hover);
   outline-offset: 2px;
+}
+
+.external-link-icon {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.35em;
+  font-size: 0.85em;
 }
 
 .price-table {


### PR DESCRIPTION
## Summary
- add a shared 2px focus-visible outline and improve button focus states for better keyboard visibility
- provide natural-language labels, titles, and hidden icons on "ショップで確認" links to clarify external navigation
- include descriptive titles on external deal cards referencing their source shop

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ca830c08588326b09742a3b7be8711