### PR TITLE
Clamp long shop names to two lines

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -162,7 +162,9 @@ export function getStaticPaths() {
                         <tr data-price={it.price} data-eff={eff}>
                           <td>{it.store}</td>
                           <td>
-                            {it.shopName}
+                            <span class="shop-name" title={it.shopName}>
+                              {it.shopName}
+                            </span>
                             <a
                               href={it.itemUrl}
                               target="_blank"
@@ -213,7 +215,9 @@ export function getStaticPaths() {
                         return (
                           <tr data-price={it.price} data-eff={eff}>
                             <td>
-                              {it.shopName}
+                              <span class="shop-name" title={it.shopName}>
+                                {it.shopName}
+                              </span>
                               <a
                                 href={it.itemUrl}
                                 target="_blank"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -289,6 +289,17 @@ label {
   vertical-align: top;
 }
 
+.price-table .shop-name {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 4px;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
 .price-table tbody tr:nth-child(even) {
   background: var(--table-row-alt-bg);
 }


### PR DESCRIPTION
## Summary
- clamp shop titles in price tables to two lines and expose full text via title attributes
- add shared styling to prevent layout shifts for long shop names

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caeec831e483268b82606fc41fb1e5