### PR TITLE
feat: convert price tables to mobile cards

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -68,16 +68,22 @@ if (!bestRecommended && list.length && skuInfo?.brandHints?.length) {
     bestRecommended = cand.reduce((min, it) => (it.price < min.price ? it : min), cand[0]);
   }
 }
+function formatCurrency(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '';
+  return `${Math.round(num).toLocaleString('ja-JP')}円`;
+}
+
 function formatPrice(it) {
   if (!it) return '';
-  return `${it.price}円`;
+  return formatCurrency(it.price);
 }
 
 function formatSummary(it) {
   if (!it) return '';
   if (it.pointRate) {
-    const eff = Math.round(it.price * (100 - it.pointRate) / 100);
-    return `${formatPrice(it)}（ポイント${it.pointRate}%で実質${eff}円）`;
+    const eff = Math.floor(it.price * (100 - it.pointRate) / 100);
+    return `${formatPrice(it)}（ポイント${it.pointRate}%で実質${formatCurrency(eff)}）`;
   }
   return formatPrice(it);
 }
@@ -146,13 +152,13 @@ export function getStaticPaths() {
               <>
                 {hasAllPoints && <button class="sort-toggle">実質価格順に切替</button>}
                 <table class="price-table">
-                  <thead>
+                  <thead class="sr-only">
                     <tr>
-                      <th>ストア</th>
-                      <th>ショップ</th>
-                      <th>価格</th>
-                      <th>ポイント</th>
-                      <th>実質価格<br/><span class="small">（ポイント込み）</span></th>
+                      <th id="col-all-store" scope="col">ストア</th>
+                      <th id="col-all-shop" scope="col">ショップ</th>
+                      <th id="col-all-price" scope="col" data-column="price">価格</th>
+                      <th id="col-all-point" scope="col" data-column="points">ポイント</th>
+                      <th id="col-all-eff" scope="col" data-column="effective">実質価格<br/><span class="small">（ポイント込み）</span></th>
                     </tr>
                   </thead>
                   <tbody>
@@ -160,8 +166,8 @@ export function getStaticPaths() {
                       const eff = Math.floor(it.price * (100 - (it.pointRate ?? 0)) / 100);
                       return (
                         <tr data-price={it.price} data-eff={eff}>
-                          <td>{it.store}</td>
-                          <td>
+                          <td headers="col-all-store" data-label="ストア" data-cell="store">{it.store}</td>
+                          <td headers="col-all-shop" data-label="ショップ" data-cell="shop">
                             <span class="shop-name" title={it.shopName}>
                               {it.shopName}
                             </span>
@@ -176,9 +182,9 @@ export function getStaticPaths() {
                               <span aria-hidden="true" class="external-link-icon">↗</span>
                             </a>
                           </td>
-                          <td>{formatPrice(it)}</td>
-                          <td>{it.pointRate ? `${it.pointRate}%` : '-'}</td>
-                          <td>{eff}円</td>
+                          <td headers="col-all-price" data-label="価格" data-cell="price">{formatPrice(it)}</td>
+                          <td headers="col-all-point" data-label="ポイント" data-cell="points">{it.pointRate ? `${it.pointRate}%` : '-'}</td>
+                          <td headers="col-all-eff" data-label="実質価格" data-cell="effective">{formatCurrency(eff)}</td>
                         </tr>
                       );
                     })}
@@ -201,12 +207,12 @@ export function getStaticPaths() {
                 <>
                   {sec.hasPoints && <button class="sort-toggle">実質価格順に切替</button>}
                   <table class="price-table">
-                    <thead>
+                    <thead class="sr-only">
                       <tr>
-                        <th>ショップ</th>
-                        <th>価格</th>
-                        <th>ポイント</th>
-                        <th>実質価格<br/><span class="small">（ポイント込み）</span></th>
+                        <th id={`col-${sec.key}-shop`} scope="col">ショップ</th>
+                        <th id={`col-${sec.key}-price`} scope="col" data-column="price">価格</th>
+                        <th id={`col-${sec.key}-point`} scope="col" data-column="points">ポイント</th>
+                        <th id={`col-${sec.key}-eff`} scope="col" data-column="effective">実質価格<br/><span class="small">（ポイント込み）</span></th>
                       </tr>
                     </thead>
                     <tbody>
@@ -214,7 +220,7 @@ export function getStaticPaths() {
                         const eff = Math.floor(it.price * (100 - (it.pointRate ?? 0)) / 100);
                         return (
                           <tr data-price={it.price} data-eff={eff}>
-                            <td>
+                            <td headers={`col-${sec.key}-shop`} data-label="ショップ" data-cell="shop">
                               <span class="shop-name" title={it.shopName}>
                                 {it.shopName}
                               </span>
@@ -229,9 +235,9 @@ export function getStaticPaths() {
                                 <span aria-hidden="true" class="external-link-icon">↗</span>
                               </a>
                             </td>
-                            <td>{formatPrice(it)}</td>
-                            <td>{it.pointRate ? `${it.pointRate}%` : '-'}</td>
-                            <td>{eff}円</td>
+                            <td headers={`col-${sec.key}-price`} data-label="価格" data-cell="price">{formatPrice(it)}</td>
+                            <td headers={`col-${sec.key}-point`} data-label="ポイント" data-cell="points">{it.pointRate ? `${it.pointRate}%` : '-'}</td>
+                            <td headers={`col-${sec.key}-eff`} data-label="実質価格" data-cell="effective">{formatCurrency(eff)}</td>
                           </tr>
                         );
                       })}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,6 +19,7 @@
   --control-border: #2f3a4d;
   --tab-bg: #1f2735;
   --tab-border: #334155;
+  --card-bg: #141823;
   --chip-rakuten-bg: #8b1a1a;
   --chip-rakuten-fg: #ffffff;
   --chip-yahoo-bg: #134e4a;
@@ -269,10 +270,14 @@ label {
   font-size: 0.85em;
 }
 
-.price-table {
+.price-table { 
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 16px;
+}
+
+.price-section {
+  overflow-x: clip;
 }
 
 .price-table thead th {
@@ -282,11 +287,33 @@ label {
   text-align: left;
 }
 
+.price-table thead th[data-column="price"],
+.price-table thead th[data-column="points"],
+.price-table thead th[data-column="effective"] {
+  text-align: right;
+}
+
 .price-table th,
 .price-table td {
   padding: 10px 12px;
   border-bottom: 1px solid var(--border-subtle);
   vertical-align: top;
+}
+
+.price-table td[data-cell="price"],
+.price-table td[data-cell="points"],
+.price-table td[data-cell="effective"] {
+  text-align: right;
+}
+
+.price-table td[data-cell="price"],
+.price-table td[data-cell="points"],
+.price-table td[data-cell="effective"] {
+  font-variant-numeric: tabular-nums;
+}
+
+.price-table td[data-cell="effective"] {
+  font-weight: 700;
 }
 
 .price-table .shop-name {
@@ -302,6 +329,97 @@ label {
 
 .price-table tbody tr:nth-child(even) {
   background: var(--table-row-alt-bg);
+}
+
+@media (max-width: 768px) {
+  .sr-only {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .price-table {
+    display: block;
+    width: 100%;
+  }
+
+  .price-table tbody {
+    display: grid;
+    gap: 12px;
+  }
+
+  .price-table tbody tr {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 16px;
+    border-radius: 12px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .price-table tbody tr:nth-child(even) {
+    background: var(--card-bg);
+  }
+
+  .price-table th,
+  .price-table td {
+    padding: 0;
+    border: 0;
+  }
+
+  .price-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  .price-table td::before {
+    content: attr(data-label);
+    color: var(--fg-muted);
+    font-weight: 600;
+    opacity: 0.7;
+    margin-right: 8px;
+  }
+
+  .price-table td[data-cell="shop"] {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .price-table td[data-cell="shop"]::before {
+    margin: 0 0 4px;
+  }
+
+  .price-table td[data-cell="shop"] .shop-name {
+    margin-bottom: 0;
+  }
+
+  .price-table td[data-cell="shop"] a {
+    display: block;
+    width: 100%;
+    text-align: center;
+    background: var(--link);
+    color: var(--fg-inverted);
+    padding: 10px 14px;
+    border-radius: 8px;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .price-table td[data-cell="shop"] a:hover,
+  .price-table td[data-cell="shop"] a:focus-visible {
+    background: var(--link-hover);
+    color: var(--fg-inverted);
+  }
 }
 
 .price-section[data-source-status="partial"] h2,


### PR DESCRIPTION
## Summary
- maintain table semantics by wiring up column headers and data labels for the price tables
- add currency formatting and styling tweaks to emphasise effective prices
- introduce responsive card styling so mobile widths show tappable cards with full-width shop buttons

## Testing
- npm run test:a11y

------
https://chatgpt.com/codex/tasks/task_e_68cba259cbf0832688a6d21c316bd5d0