### PR TITLE
feat: promote shop check action to button

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -159,6 +159,7 @@ export function getStaticPaths() {
                       <th id="col-all-price" scope="col" data-column="price">価格</th>
                       <th id="col-all-point" scope="col" data-column="points">ポイント</th>
                       <th id="col-all-eff" scope="col" data-column="effective">実質価格<br/><span class="small">（ポイント込み）</span></th>
+                      <th id="col-all-action" scope="col" data-column="action" class="sr-only">ショップで確認</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -171,7 +172,17 @@ export function getStaticPaths() {
                             <span class="shop-name" title={it.shopName}>
                               {it.shopName}
                             </span>
+                          </td>
+                          <td headers="col-all-price" data-label="価格" data-cell="price">{formatPrice(it)}</td>
+                          <td headers="col-all-point" data-label="ポイント" data-cell="points">{it.pointRate ? `${it.pointRate}%` : '-'}</td>
+                          <td headers="col-all-eff" data-label="実質価格" data-cell="effective">{formatCurrency(eff)}</td>
+                          <td
+                            headers="col-all-action"
+                            data-label="ショップで確認"
+                            data-cell="action"
+                          >
                             <a
+                              class="shop-link-button"
                               href={it.itemUrl}
                               target="_blank"
                               rel="nofollow noopener"
@@ -182,9 +193,6 @@ export function getStaticPaths() {
                               <span aria-hidden="true" class="external-link-icon">↗</span>
                             </a>
                           </td>
-                          <td headers="col-all-price" data-label="価格" data-cell="price">{formatPrice(it)}</td>
-                          <td headers="col-all-point" data-label="ポイント" data-cell="points">{it.pointRate ? `${it.pointRate}%` : '-'}</td>
-                          <td headers="col-all-eff" data-label="実質価格" data-cell="effective">{formatCurrency(eff)}</td>
                         </tr>
                       );
                     })}
@@ -213,6 +221,7 @@ export function getStaticPaths() {
                         <th id={`col-${sec.key}-price`} scope="col" data-column="price">価格</th>
                         <th id={`col-${sec.key}-point`} scope="col" data-column="points">ポイント</th>
                         <th id={`col-${sec.key}-eff`} scope="col" data-column="effective">実質価格<br/><span class="small">（ポイント込み）</span></th>
+                        <th id={`col-${sec.key}-action`} scope="col" data-column="action" class="sr-only">ショップで確認</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -224,7 +233,17 @@ export function getStaticPaths() {
                               <span class="shop-name" title={it.shopName}>
                                 {it.shopName}
                               </span>
+                            </td>
+                            <td headers={`col-${sec.key}-price`} data-label="価格" data-cell="price">{formatPrice(it)}</td>
+                            <td headers={`col-${sec.key}-point`} data-label="ポイント" data-cell="points">{it.pointRate ? `${it.pointRate}%` : '-'}</td>
+                            <td headers={`col-${sec.key}-eff`} data-label="実質価格" data-cell="effective">{formatCurrency(eff)}</td>
+                            <td
+                              headers={`col-${sec.key}-action`}
+                              data-label="ショップで確認"
+                              data-cell="action"
+                            >
                               <a
+                                class="shop-link-button"
                                 href={it.itemUrl}
                                 target="_blank"
                                 rel="nofollow noopener"
@@ -235,9 +254,6 @@ export function getStaticPaths() {
                                 <span aria-hidden="true" class="external-link-icon">↗</span>
                               </a>
                             </td>
-                            <td headers={`col-${sec.key}-price`} data-label="価格" data-cell="price">{formatPrice(it)}</td>
-                            <td headers={`col-${sec.key}-point`} data-label="ポイント" data-cell="points">{it.pointRate ? `${it.pointRate}%` : '-'}</td>
-                            <td headers={`col-${sec.key}-eff`} data-label="実質価格" data-cell="effective">{formatCurrency(eff)}</td>
                           </tr>
                         );
                       })}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -266,8 +266,36 @@ label {
 .external-link-icon {
   display: inline-flex;
   align-items: center;
-  margin-left: 0.35em;
   font-size: 0.85em;
+}
+
+.shop-link-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4em;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: var(--link);
+  color: var(--fg-inverted);
+  font-weight: 700;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.shop-link-button:hover,
+.shop-link-button:focus-visible {
+  background: var(--link-hover);
+  color: var(--fg-inverted);
+}
+
+.shop-link-button:focus-visible {
+  outline: 2px solid var(--link-hover);
+  outline-offset: 2px;
+}
+
+.shop-link-button .external-link-icon {
+  margin-left: 0;
 }
 
 .price-table { 
@@ -314,6 +342,14 @@ label {
 
 .price-table td[data-cell="effective"] {
   font-weight: 700;
+}
+
+.price-table td[data-cell="action"] {
+  text-align: right;
+}
+
+.price-table td[data-cell="action"] .shop-link-button {
+  min-width: 180px;
 }
 
 .price-table .shop-name {
@@ -403,22 +439,20 @@ label {
     margin-bottom: 0;
   }
 
-  .price-table td[data-cell="shop"] a {
-    display: block;
-    width: 100%;
-    text-align: center;
-    background: var(--link);
-    color: var(--fg-inverted);
-    padding: 10px 14px;
-    border-radius: 8px;
-    font-weight: 700;
-    text-decoration: none;
+  .price-table td[data-cell="action"] {
+    margin-top: 4px;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-end;
   }
 
-  .price-table td[data-cell="shop"] a:hover,
-  .price-table td[data-cell="shop"] a:focus-visible {
-    background: var(--link-hover);
-    color: var(--fg-inverted);
+  .price-table td[data-cell="action"]::before {
+    content: "";
+    display: none;
+  }
+
+  .price-table td[data-cell="action"] .shop-link-button {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated action column that surfaces the shop link as a button on desktop and mobile tables
- style the shop link button for accessibility, hover, and focus states
- ensure the mobile card layout shows a full-width primary action at the bottom of each card

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbb3f4357c8326b23d6c58ee52c815