### PR TITLE
Add store badges to price tables

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -95,6 +95,16 @@ function getShopLinkDescription(name) {
   return `${name}で商品の詳細を確認できます（新しいタブで開きます）`;
 }
 
+function getStoreBadgeClass(store) {
+  if (store === '楽天') {
+    return 'store-badge store-badge--rakuten';
+  }
+  if (typeof store === 'string' && store.toLowerCase() === 'yahoo') {
+    return 'store-badge store-badge--yahoo';
+  }
+  return 'store-badge';
+}
+
 export function getStaticPaths() {
   return skus.map(s => ({ params: { sku: s.id } }));
 }
@@ -166,8 +176,14 @@ export function getStaticPaths() {
                     {allList.map(it => {
                       const eff = Math.floor(it.price * (100 - (it.pointRate ?? 0)) / 100);
                       return (
-                        <tr data-price={it.price} data-eff={eff}>
-                          <td headers="col-all-store" data-label="ストア" data-cell="store">{it.store}</td>
+                        <tr class="has-store-badge" data-price={it.price} data-eff={eff}>
+                          <td
+                            headers="col-all-store"
+                            data-label="ストア"
+                            data-cell="store"
+                          >
+                            <span class={getStoreBadgeClass(it.store)}>{it.store}</span>
+                          </td>
                           <td headers="col-all-shop" data-label="ショップ" data-cell="shop">
                             <span class="shop-name" title={it.shopName}>
                               {it.shopName}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -298,7 +298,36 @@ label {
   margin-left: 0;
 }
 
-.price-table { 
+.store-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 10px;
+  border-radius: 9999px;
+  background: var(--control-bg);
+  color: var(--badge-fg);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  text-transform: none;
+  white-space: nowrap;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+}
+
+.store-badge--rakuten {
+  background: var(--chip-rakuten-bg);
+  color: var(--chip-rakuten-fg);
+  border-color: rgba(139, 26, 26, 0.4);
+}
+
+.store-badge--yahoo {
+  background: var(--chip-yahoo-bg);
+  color: var(--chip-yahoo-fg);
+  border-color: rgba(19, 78, 74, 0.4);
+}
+
+.price-table {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 16px;
@@ -352,6 +381,11 @@ label {
   min-width: 180px;
 }
 
+.price-table td[data-cell="store"] {
+  white-space: nowrap;
+  width: 1%;
+}
+
 .price-table .shop-name {
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -399,6 +433,11 @@ label {
     border-radius: 12px;
     background: var(--card-bg);
     border: 1px solid var(--border-subtle);
+    position: relative;
+  }
+
+  .price-table tbody tr.has-store-badge {
+    padding-top: 56px;
   }
 
   .price-table tbody tr:nth-child(even) {
@@ -437,6 +476,19 @@ label {
 
   .price-table td[data-cell="shop"] .shop-name {
     margin-bottom: 0;
+  }
+
+  .price-table td[data-cell="store"] {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    display: block;
+    padding: 0;
+  }
+
+  .price-table td[data-cell="store"]::before {
+    content: "";
+    display: none;
   }
 
   .price-table td[data-cell="action"] {


### PR DESCRIPTION
## Summary
- add a helper that renders Rakuten and Yahoo mall labels as store badges in the price tables
- style the new badges for desktop and position them in the top-right corner of mobile cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe151af1483268537d30bc4c707f9