### PR TITLE
Adjust mobile store badge layout

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -510,16 +510,22 @@ label {
   }
 
   .price-table td[data-cell="store"] {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    display: block;
+    position: static;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
     padding: 0;
+    margin-bottom: 4px;
   }
 
   .price-table td[data-cell="store"]::before {
     content: "";
     display: none;
+  }
+
+  .price-table td[data-cell="store"] .store-badge {
+    max-width: 100%;
+    white-space: normal;
   }
 
   .price-table td[data-cell="action"] {


### PR DESCRIPTION
## Summary
- reposition the mobile store badge within price cards using flex layout
- prevent the badge from overflowing by allowing it to wrap within the card

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd21cf92908326b268a89bfa27854c