### PR TITLE
Hide price section headings visually

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -69,7 +69,7 @@ const allList = [
 ].sort((a, b) => a.effective - b.effective);
 const hasAllPoints = allList.some(it => Number(it.pointRate) > 0);
 const sections = [
-  { name: 'Rakuten', key: 'rakuten', list: rakutenList, status: data?.sourceStatus?.rakuten ?? 'fail', hasPoints: rakutenList.some(it => Number(it.pointRate) > 0) },
+  { name: '楽天', key: 'rakuten', list: rakutenList, status: data?.sourceStatus?.rakuten ?? 'fail', hasPoints: rakutenList.some(it => Number(it.pointRate) > 0) },
   { name: 'Yahoo', key: 'yahoo', list: yahooList, status: data?.sourceStatus?.yahoo ?? 'fail', hasPoints: yahooList.some(it => Number(it.pointRate) > 0) }
 ];
 const statusMessages = {
@@ -182,7 +182,7 @@ export function getStaticPaths() {
             <button type="button" data-tab="yahoo">Yahooのみ</button>
           </div>
           <div class="price-section tab-content" data-tab="all">
-            <h2>全ストア</h2>
+            <h2 class="sr-only">全ストア</h2>
             {allList.length ? (
               <>
                 {hasAllPoints && <button class="sort-toggle">価格順に切替</button>}
@@ -254,12 +254,10 @@ export function getStaticPaths() {
           </div>
           {sections.map(sec => (
             <div class="price-section tab-content" data-tab={sec.key} data-source-status={sec.status} style="display:none">
-              <h2>
-                {sec.name}
-                {sec.status !== 'ok' && (
-                  <span class="status-icon--warn" aria-label={statusMessages[sec.status]} title={statusMessages[sec.status]}>⚠️</span>
-                )}
-              </h2>
+              <h2 class="sr-only">{sec.name}</h2>
+              {sec.status !== 'ok' && (
+                <span class="status-icon--warn" aria-label={statusMessages[sec.status]} title={statusMessages[sec.status]}>⚠️</span>
+              )}
               {sec.list.length ? (
               <>
                   {sec.hasPoints && <button class="sort-toggle">価格順に切替</button>}


### PR DESCRIPTION
## Summary
- hide the All, 楽天, and Yahoo price section headings using the existing sr-only utility
- rename the Rakuten section heading to 楽天 for consistency with button labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd235c60b88326b7ada3fed464304f