### PR TITLE
Remove extra padding for store badge rows

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -451,10 +451,6 @@ label {
     position: relative;
   }
 
-  .price-table tbody tr.has-store-badge {
-    padding-top: 56px;
-  }
-
   .price-table tbody tr:nth-child(even) {
     background: var(--card-bg);
   }


### PR DESCRIPTION
## Summary
- remove the mobile-only padding-top override applied to price table rows with store badges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd282fbaa08326b7f4371b2d4f2302