### PR TITLE
Fix chart fetch URL for non-module script

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -454,8 +454,7 @@ export function getStaticPaths() {
                 ctx.strokeStyle = '#0070f3';
                 ctx.lineWidth = Math.max(1, dpr);
                 ctx.stroke();
-                msg.textContent = '';
-                showDebug('');
+                  msg.textContent = '';
               }
 
               function handleResize() {
@@ -468,10 +467,10 @@ export function getStaticPaths() {
               async function loadChart() {
                 try {
                   const url = new URL(
-                    `${import.meta.env.BASE_URL}data/price-history/${sku}.json`,
-                    location.origin,
+                    `data/price-history/${sku}.json?t=${Date.now()}`,
+                    document.baseURI,
                   );
-                  url.searchParams.set('t', Date.now().toString());
+                  showDebug(url.toString());
                   const res = await fetch(url);
                   if (!res.ok) {
                     const message = `HTTP ${res.status} ${url.toString()}`;
@@ -490,7 +489,7 @@ export function getStaticPaths() {
                   chartData = filtered;
                   canvas.style.display = '';
                   msg.textContent = '';
-                  showDebug('');
+                  showDebug(url.toString());
                   renderChart();
                 } catch (err) {
                   console.error(err);


### PR DESCRIPTION
## Summary
- resolve chart history URL using document.baseURI instead of import.meta env
- include timestamp query directly in constructed URL string
- surface the resolved URL in the existing debug output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce49ea43fc8326aaef1f48da89e380