### PR TITLE
feat: refresh best price header cards

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -92,6 +92,8 @@ if (!bestRecommended && list.length && skuInfo?.brandHints?.length) {
 if (bestRecommended) {
   bestRecommended = { ...bestRecommended, effective: Number.isFinite(bestRecommended.effective) ? bestRecommended.effective : getEffectivePriceValue(bestRecommended) };
 }
+const bestTodayCard = getPriceCardModel(bestToday, { prefix: '最安' });
+const bestRecommendedCard = getPriceCardModel(bestRecommended, { prefix: '推奨' });
 function formatCurrency(value) {
   const num = Number(value);
   if (!Number.isFinite(num)) return '';
@@ -103,21 +105,52 @@ function formatPrice(it) {
   return formatCurrency(it.price);
 }
 
-function formatSummary(it) {
-  if (!it) return '';
-  const pointRate = Number(it.pointRate ?? 0);
-  const effective = Number.isFinite(it.effective) ? it.effective : getEffectivePriceValue(it);
-  if (pointRate > 0) {
-    return `${formatPrice(it)}（ポイント${pointRate}%で実質${formatCurrency(effective)}）`;
-  }
-  return formatPrice(it);
-}
-
 function getShopLinkDescription(name) {
   if (!name) {
     return 'ショップで商品の詳細を確認できます（新しいタブで開きます）';
   }
   return `${name}で商品の詳細を確認できます（新しいタブで開きます）`;
+}
+
+function truncateShopName(name, maxLength = 15) {
+  if (!name) return '';
+  if (name.length <= maxLength) {
+    return name;
+  }
+  return `${name.slice(0, maxLength)}…`;
+}
+
+function getPriceCardModel(item, { prefix }) {
+  if (!item) return null;
+  const rawPrice = Number(item.price);
+  if (!Number.isFinite(rawPrice) || rawPrice <= 0) {
+    return null;
+  }
+
+  const effectiveValue = Number.isFinite(item.effective) ? item.effective : getEffectivePriceValue(item);
+  const pointRate = Number(item.pointRate ?? 0);
+  const priceText = formatCurrency(rawPrice);
+  const hasEffectiveLine = Number.isFinite(effectiveValue) && effectiveValue > 0 && effectiveValue !== rawPrice;
+  const effectiveText = hasEffectiveLine ? formatCurrency(effectiveValue) : null;
+
+  const resolvedName = item.shopName ?? '';
+  const displayNameSource = resolvedName || 'ショップ';
+
+  return {
+    hasEffectiveLine,
+    prefix,
+    primaryValue: hasEffectiveLine ? effectiveText : priceText,
+    primaryAriaLabel: hasEffectiveLine ? `実質価格 ${effectiveText}` : `通常価格 ${priceText}`,
+    secondaryPrice: priceText,
+    secondaryPriceAriaLabel: `通常価格 ${priceText}`,
+    hasPoints: hasEffectiveLine && pointRate > 0,
+    pointRateText: `${pointRate}%`,
+    pointRateAriaLabel: `ポイント還元率 ${pointRate}%`,
+    shopName: resolvedName,
+    shopDisplayName: truncateShopName(displayNameSource),
+    shopTitle: resolvedName || undefined,
+    itemUrl: item.itemUrl
+  };
 }
 
 function getStoreBadgeClass(store) {
@@ -162,19 +195,100 @@ export function getStaticPaths() {
       )}
       {priceInfo ? (
         <>
-          <div>
+          <div class="best-price">
             <h2>最安情報</h2>
-            <ul>
-              <li>今日の最安: {bestToday ? `${formatSummary(bestToday)} (${bestToday.shopName})` : 'データ少'}</li>
-              {skuInfo?.brandHints?.length && (
-                <li>
-                  推奨安（ブランド一致優先）:
-                  {bestRecommended
-                    ? `${formatSummary(bestRecommended)} (${bestRecommended.shopName})`
-                    : '該当なし'}
-                </li>
-              )}
-            </ul>
+            <div class="best-price-cards">
+              <section class="best-price-card" role="region" aria-labelledby="best-today-heading">
+                <p class="best-price-card__label" id="best-today-heading">今日の最安</p>
+                {bestTodayCard ? (
+                  <>
+                    <p class="best-price-card__line best-price-card__line--primary">
+                      {bestTodayCard.hasEffectiveLine ? (
+                        <>
+                          <span class="best-price-card__prefix">{bestTodayCard.prefix}</span>
+                          <span class="best-price-card__value" aria-label={bestTodayCard.primaryAriaLabel}>{bestTodayCard.primaryValue}</span>
+                        </>
+                      ) : (
+                        <span class="best-price-card__value" aria-label={bestTodayCard.primaryAriaLabel}>{bestTodayCard.primaryValue}</span>
+                      )}
+                    </p>
+                    {bestTodayCard.hasEffectiveLine && (
+                      <p class="best-price-card__line best-price-card__line--secondary">
+                        <span aria-label={bestTodayCard.secondaryPriceAriaLabel}>通常 {bestTodayCard.secondaryPrice}</span>
+                        {bestTodayCard.hasPoints && (
+                          <>
+                            <span aria-hidden="true"> / </span>
+                            <span aria-label={bestTodayCard.pointRateAriaLabel}>ポイント {bestTodayCard.pointRateText}</span>
+                          </>
+                        )}
+                      </p>
+                    )}
+                    {bestTodayCard.itemUrl && (
+                      <p class="best-price-card__line best-price-card__line--link">
+                        <a
+                          href={bestTodayCard.itemUrl}
+                          target="_blank"
+                          rel="nofollow noopener"
+                          class="best-price-card__link"
+                          title={bestTodayCard.shopTitle}
+                          aria-label={getShopLinkDescription(bestTodayCard.shopName || bestTodayCard.shopDisplayName)}
+                        >
+                          {bestTodayCard.shopDisplayName} で確認 <span aria-hidden="true">↗</span>
+                        </a>
+                      </p>
+                    )}
+                  </>
+                ) : (
+                  <p class="best-price-card__line best-price-card__line--empty">データ少</p>
+                )}
+              </section>
+              {skuInfo?.brandHints?.length ? (
+                <section class="best-price-card" role="region" aria-labelledby="best-recommended-heading">
+                  <p class="best-price-card__label" id="best-recommended-heading">推奨安</p>
+                  {bestRecommendedCard ? (
+                    <>
+                      <p class="best-price-card__line best-price-card__line--primary">
+                        {bestRecommendedCard.hasEffectiveLine ? (
+                          <>
+                            <span class="best-price-card__prefix">{bestRecommendedCard.prefix}</span>
+                            <span class="best-price-card__value" aria-label={bestRecommendedCard.primaryAriaLabel}>{bestRecommendedCard.primaryValue}</span>
+                          </>
+                        ) : (
+                          <span class="best-price-card__value" aria-label={bestRecommendedCard.primaryAriaLabel}>{bestRecommendedCard.primaryValue}</span>
+                        )}
+                      </p>
+                      {bestRecommendedCard.hasEffectiveLine && (
+                        <p class="best-price-card__line best-price-card__line--secondary">
+                          <span aria-label={bestRecommendedCard.secondaryPriceAriaLabel}>通常 {bestRecommendedCard.secondaryPrice}</span>
+                          {bestRecommendedCard.hasPoints && (
+                            <>
+                              <span aria-hidden="true"> / </span>
+                              <span aria-label={bestRecommendedCard.pointRateAriaLabel}>ポイント {bestRecommendedCard.pointRateText}</span>
+                            </>
+                          )}
+                        </p>
+                      )}
+                      {bestRecommendedCard.itemUrl && (
+                        <p class="best-price-card__line best-price-card__line--link">
+                          <a
+                            href={bestRecommendedCard.itemUrl}
+                            target="_blank"
+                            rel="nofollow noopener"
+                            class="best-price-card__link"
+                            title={bestRecommendedCard.shopTitle}
+                            aria-label={getShopLinkDescription(bestRecommendedCard.shopName || bestRecommendedCard.shopDisplayName)}
+                          >
+                            {bestRecommendedCard.shopDisplayName} で確認 <span aria-hidden="true">↗</span>
+                          </a>
+                        </p>
+                      )}
+                    </>
+                  ) : (
+                    <p class="best-price-card__line best-price-card__line--empty">該当なし</p>
+                  )}
+                </section>
+              ) : null}
+            </div>
           </div>
           <div class="tabs">
             <button type="button" data-tab="all" class="active">全ストア</button>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -167,6 +167,95 @@ label {
   font-weight: 600;
 }
 
+.best-price {
+  margin-bottom: 24px;
+}
+
+.best-price-cards {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.best-price-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.best-price-card:focus-within {
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 1px var(--border-strong);
+}
+
+.best-price-card__label {
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--fg-muted);
+}
+
+.best-price-card__line {
+  margin: 0;
+}
+
+.best-price-card__line--primary {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: var(--fg-strong);
+}
+
+.best-price-card__prefix {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.best-price-card__value {
+  font-variant-numeric: tabular-nums;
+}
+
+.best-price-card__line--secondary {
+  font-size: 0.9375rem;
+  color: var(--fg-muted);
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.best-price-card__line--link {
+  margin-top: auto;
+  font-weight: 700;
+}
+
+.best-price-card__line--empty {
+  font-size: 0.9375rem;
+  color: var(--fg-muted);
+}
+
+.best-price-card__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 700;
+}
+
+.best-price-card__link span[aria-hidden="true"] {
+  font-size: 0.875em;
+}
+
 .status-icon--warn {
   margin-left: 4px;
   font-size: 0.9em;


### PR DESCRIPTION
## Summary
- replace the best price summary list with dual cards that emphasise effective price and accessible labelling
- add truncation and link text updates for shop names while handling point rate display rules
- style the new header cards for responsive stacked layout with focus-visible states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce52ced0b88326b1a0f2e0dddf64ca