### PR TITLE
Improve line breaking for mixed-language content

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,8 +5,8 @@ const { formatted } = await getLastUpdated();
 ---
 <footer class="site-footer">
   <div class="wrap small">
-    <p>最終更新 {formatted}</p>
-    <p>
+    <p class="jp-copy">最終更新 {formatted}</p>
+    <p class="jp-copy">
       <a href="./about/sources/">データ出典</a>
       <span aria-hidden="true"> / </span>
       <a href="./about/affiliate/">アフィリエイトについて</a>

--- a/src/lib/safe-break.ts
+++ b/src/lib/safe-break.ts
@@ -1,0 +1,44 @@
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizeUnitMatch(num: string, spaces: string, unit: string): string {
+  const preservedSpaces = spaces
+    .replace(/ /g, '&nbsp;')
+    .replace(/\u3000/g, '　');
+  return `<span class="nobr">${num}${preservedSpaces}${unit}</span>`;
+}
+
+function applySafeBreaks(html: string): string {
+  let result = html;
+
+  result = result.replace(/(\d+(?:[\.,]\d+)?)(\s*)([GTM]B)/gi, (_, num, spaces, unit) =>
+    normalizeUnitMatch(num, spaces, unit)
+  );
+
+  result = result.replace(/\s–\s/g, () => '<wbr>&nbsp;&ndash;&nbsp;');
+
+  result = result.replace(/価格一覧/g, '<span class="nobr">価格一覧</span>');
+
+  result = result
+    .replace(/・(?!<wbr>)/g, '・<wbr>')
+    .replace(/／(?!<wbr>)/g, '／<wbr>')
+    .replace(/　(?!<wbr>)/g, '　<wbr>');
+
+  return result.replace(/<wbr>$/g, '');
+}
+
+export function safeBreak(title: string): string {
+  if (!title) {
+    return '';
+  }
+
+  const escaped = escapeHtml(title);
+  return applySafeBreaks(escaped);
+}
+

--- a/src/pages/about/affiliate.astro
+++ b/src/pages/about/affiliate.astro
@@ -1,6 +1,7 @@
 ---
 import "../../styles/global.css";
 import Footer from "../../components/Footer.astro";
+import { safeBreak } from "../../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
 ---
 <html lang="ja">
@@ -13,11 +14,11 @@ const BASE_URL = import.meta.env.BASE_URL;
   <body>
     <div class="wrap">
       <a href="./" class="small">← トップ</a>
-      <h1>アフィリエイトについて</h1>
-      <p>一部のリンクはアフィリエイトリンクを含みます。購入により、運営に紹介料が支払われる場合があります。</p>
-      <p>紹介料は商品価格やお客様の負担に影響しません。</p>
-      <p>本サイトの掲載順・評価は、取得時点の情報（価格・在庫・仕様）と独自ルール（ノイズ除外など）に基づきます。</p>
-      <p>購入の最終判断は、必ずリンク先の最新情報をご確認ください。</p>
+      <h1 set:html={safeBreak("アフィリエイトについて")}></h1>
+      <p class="jp-copy">一部のリンクはアフィリエイトリンクを含みます。購入により、運営に紹介料が支払われる場合があります。</p>
+      <p class="jp-copy">紹介料は商品価格やお客様の負担に影響しません。</p>
+      <p class="jp-copy">本サイトの掲載順・評価は、取得時点の情報（価格・在庫・仕様）と独自ルール（ノイズ除外など）に基づきます。</p>
+      <p class="jp-copy">購入の最終判断は、必ずリンク先の最新情報をご確認ください。</p>
     </div>
     <Footer />
   </body>

--- a/src/pages/about/sources.astro
+++ b/src/pages/about/sources.astro
@@ -1,6 +1,7 @@
 ---
 import "../../styles/global.css";
 import Footer from "../../components/Footer.astro";
+import { safeBreak } from "../../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
 ---
 <html lang="ja">
@@ -13,16 +14,16 @@ const BASE_URL = import.meta.env.BASE_URL;
   <body>
     <div class="wrap">
       <a href="./" class="small">← トップ</a>
-      <h1>データ出典と更新について</h1>
-      <p>本サイトはメーカーや公式ストアの情報を、公式RSS・公式APIを中心に毎日自動で取り込み、必要に応じて最新成功分を表示しています。</p>
-      <h2>ノイズ除外の基準</h2>
+      <h1 set:html={safeBreak("データ出典と更新について")}></h1>
+      <p class="jp-copy">本サイトはメーカーや公式ストアの情報を、公式RSS・公式APIを中心に毎日自動で取り込み、必要に応じて最新成功分を表示しています。</p>
+      <h2 set:html={safeBreak("ノイズ除外の基準")}></h2>
       <ul>
         <li>求人・提供／PRなど、価格比較に直接関係しない投稿</li>
         <li>重複告知や機械的な再投稿</li>
         <li>価格・在庫など判断材料が欠けている告知</li>
       </ul>
-      <p class="small">価格・在庫は取得時点の参考値です。最新情報は各リンク先をご確認ください。</p>
-      <p class="small">解析や取得方法など技術的な詳細は予告なく調整される場合があります。</p>
+      <p class="small jp-copy">価格・在庫は取得時点の参考値です。最新情報は各リンク先をご確認ください。</p>
+      <p class="small jp-copy">解析や取得方法など技術的な詳細は予告なく調整される場合があります。</p>
     </div>
     <Footer />
   </body>

--- a/src/pages/calculators.astro
+++ b/src/pages/calculators.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import Footer from "../components/Footer.astro";
+import { safeBreak } from "../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
 ---
 <html lang="ja">
@@ -13,18 +14,18 @@ const BASE_URL = import.meta.env.BASE_URL;
   <body>
     <div class="wrap">
       <a href="./" class="small">← トップ</a>
-      <h1>なんでも計算室</h1>
+      <h1 set:html={safeBreak("なんでも計算室")}></h1>
       <div class="grid">
 
         <div class="card">
-          <h2>税込↔税抜</h2>
+          <h2 set:html={safeBreak("税込↔税抜")}></h2>
           <label for="p1">価格</label><input id="p1" type="number" placeholder="1000" />
           <label for="t1">税率(%)</label><input id="t1" type="number" value="10" />
           <div class="result" id="r1"></div>
         </div>
 
         <div class="card">
-          <h2>体積 m³ ↔ L</h2>
+          <h2 set:html={safeBreak("体積 m³ ↔ L")}></h2>
           <label for="p2">値</label><input id="p2" type="number" placeholder="1" />
           <label for="u2">単位</label>
           <select id="u2"><option value="m3">m³</option><option value="l">L</option></select>
@@ -32,7 +33,7 @@ const BASE_URL = import.meta.env.BASE_URL;
         </div>
 
         <div class="card">
-          <h2>画像 DPI↔px</h2>
+          <h2 set:html={safeBreak("画像 DPI↔px")}></h2>
           <label for="px3">幅(px)</label><input id="px3" type="number" placeholder="1200" />
           <label for="dpi3">DPI</label><input id="dpi3" type="number" placeholder="300" />
           <label for="mm3">用紙幅(mm)</label><input id="mm3" type="number" placeholder="210" />
@@ -40,14 +41,14 @@ const BASE_URL = import.meta.env.BASE_URL;
         </div>
 
         <div class="card">
-          <h2>歩数→距離</h2>
+          <h2 set:html={safeBreak("歩数→距離")}></h2>
           <label for="steps4">歩数</label><input id="steps4" type="number" placeholder="7000" />
           <label for="stride4">歩幅(cm)</label><input id="stride4" type="number" placeholder="65" />
           <div class="result" id="r4"></div>
         </div>
 
         <div class="card">
-          <h2>熱量 kcal ↔ kJ</h2>
+          <h2 set:html={safeBreak("熱量 kcal ↔ kJ")}></h2>
           <label for="val5">値</label><input id="val5" type="number" placeholder="500" />
           <label for="u5">単位</label>
           <select id="u5"><option value="kcal">kcal</option><option value="kj">kJ</option></select>

--- a/src/pages/deals.astro
+++ b/src/pages/deals.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import Footer from "../components/Footer.astro";
 import data from "../data/deals.json";
+import { safeBreak } from "../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
 const items = (data?.items ?? []).slice(0, 100);
 function fmt(d){ try{ return new Date(d).toLocaleString(); }catch{ return d; } }
@@ -16,8 +17,8 @@ function fmt(d){ try{ return new Date(d).toLocaleString(); }catch{ return d; } }
   <body>
     <div class="wrap">
       <a href="./" class="small">← トップ</a>
-      <h1>今日のセール・割引まとめ</h1>
-      <p class="small">主要サイトの公式情報から毎日自動で集めています。ノイズ（求人・PR等）は除外。</p>
+      <h1 set:html={safeBreak("今日のセール・割引まとめ")}></h1>
+      <p class="small jp-copy">主要サイトの公式情報から毎日自動で集めています。ノイズ（求人・PR等）は除外。</p>
       <div class="grid" style="margin-top:8px">
         {items.map((it) => (
           <a
@@ -27,13 +28,13 @@ function fmt(d){ try{ return new Date(d).toLocaleString(); }catch{ return d; } }
             rel="nofollow noopener"
             title={`${it.source}で詳細を確認できます（新しいタブが開きます）`}
           >
-            <h2 style="margin:0 0 6px 0">{it.title}</h2>
-            <p class="small" style="margin:0 0 6px 0">{it.source} / {fmt(it.date)}</p>
-            {it.description && <p style="margin:0">{it.description}</p>}
+            <h2 style="margin:0 0 6px 0" set:html={safeBreak(it.title)}></h2>
+            <p class="small jp-copy" style="margin:0 0 6px 0">{it.source} / {fmt(it.date)}</p>
+            {it.description && <p class="jp-copy" style="margin:0">{it.description}</p>}
           </a>
         ))}
       </div>
-      <p class="small" style="margin-top:8px">価格・在庫は変動します。最新情報はリンク先でご確認ください。</p>
+      <p class="small jp-copy" style="margin-top:8px">価格・在庫は変動します。最新情報はリンク先でご確認ください。</p>
     </div>
     <Footer />
   </body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import Footer from "../components/Footer.astro";
+import { safeBreak } from "../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
 const tools = [
   {
@@ -32,15 +33,15 @@ const tools = [
   </head>
   <body>
     <div class="wrap">
-      <h1>なんでも計算室＆お得チェッカー</h1>
-      <p class="small">
+      <h1 set:html={safeBreak("なんでも計算室＆お得チェッカー")}></h1>
+      <p class="small jp-copy">
         よく使う計算と今日のお得をまとめてチェック。
       </p>
       <div class="grid" style="margin-top:20px">
         {tools.map(t => (
           <a class="card" href={t.href}>
-            <h2>{t.title}</h2>
-            <p>{t.desc}</p>
+            <h2 set:html={safeBreak(t.title)}></h2>
+            <p class="jp-copy">{t.desc}</p>
             <span class="btn">{t.cta ?? "開く"}</span>
           </a>
         ))}

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -2,6 +2,7 @@
 import "../../styles/global.css";
 import Footer from "../../components/Footer.astro";
 import skus from "../../data/skus.json";
+import { safeBreak } from "../../lib/safe-break";
 const IS_DEV = import.meta.env.DEV;
 const BASE_URL = import.meta.env.BASE_URL;
 
@@ -183,16 +184,16 @@ export function getStaticPaths() {
   <body>
     <div class="wrap">
         <a href="./" class="small">← トップ</a>
-      <h1>{skuInfo ? skuInfo.q : sku} – 価格一覧</h1>
-      <p>ショップ別の価格を一覧しています。並び順は目安（価格）です。</p>
-      <p class="small">
+      <h1 set:html={safeBreak(`${skuInfo ? skuInfo.q : sku} – 価格一覧`)}></h1>
+      <p class="jp-copy">ショップ別の価格を一覧しています。並び順は <span class="nobr">目安（価格）です。</span></p>
+      <p class="small jp-copy">
         {data
           ? `取得日時: ${new Date(data.updatedAt).toLocaleString('ja-JP')}`
           : 'データ少'}
       </p>
       {skuInfo && (
         <div>
-          <h2>仕様</h2>
+          <h2 set:html={safeBreak("仕様")}></h2>
           <ul>
             {skuInfo.filters && <li>フィルタ: {skuInfo.filters.join(', ')}</li>}
             {skuInfo.brandHints && <li>ブランド候補: {skuInfo.brandHints.join(', ')}</li>}
@@ -202,7 +203,7 @@ export function getStaticPaths() {
       {priceInfo ? (
         <>
           <div class="best-price">
-            <h2>最安情報</h2>
+            <h2 set:html={safeBreak("最安情報")}></h2>
             <div class="best-price-cards">
               <section class="best-price-card" role="region" aria-labelledby="best-today-heading">
                 <p class="best-price-card__label" id="best-today-heading">今日の最安</p>
@@ -302,7 +303,7 @@ export function getStaticPaths() {
             <button type="button" data-tab="yahoo">Yahooのみ</button>
           </div>
           <div class="price-section tab-content" data-tab="all">
-            <h2 class="sr-only">全ストア</h2>
+            <h2 class="sr-only" set:html={safeBreak("全ストア")}></h2>
             {allList.length ? (
               <>
                 {hasAllPoints && <button class="sort-toggle">価格順に切替</button>}
@@ -374,7 +375,7 @@ export function getStaticPaths() {
           </div>
           {sections.map(sec => (
             <div class="price-section tab-content" data-tab={sec.key} data-source-status={sec.status} style="display:none">
-              <h2 class="sr-only">{sec.name}</h2>
+              <h2 class="sr-only" set:html={safeBreak(sec.name)}></h2>
               {sec.status !== 'ok' && (
                 <span class="status-icon--warn" aria-label={statusMessages[sec.status]} title={statusMessages[sec.status]}>⚠️</span>
               )}
@@ -440,15 +441,15 @@ export function getStaticPaths() {
               )}
             </div>
           ))}
-          <p class="small">※実質価格はポイント考慮の試算です。</p>
-          <p class="small">価格・在庫は常に変動します。購入前にリンク先で最新情報をご確認ください。</p>
-          <h2>価格推移 (30日)</h2>
+          <p class="small jp-copy">※実質価格はポイント考慮の試算です。</p>
+          <p class="small jp-copy">価格・在庫は常に変動します。購入前にリンク先で最新情報をご確認ください。</p>
+          <h2 set:html={safeBreak("価格推移 (30日)")}></h2>
           <div class="chart-container">
             <canvas id="chart" data-sku={sku}></canvas>
           </div>
           <p id="chart-msg" class="small"></p>
           <pre id="chart-debug" class="small" style="display:none" aria-live="polite"></pre>
-          <p class="small">過去データはAPI仕様・収集失敗で欠損する場合があります。</p>
+          <p class="small jp-copy">過去データはAPI仕様・収集失敗で欠損する場合があります。</p>
           <script>
             const tabButtons = document.querySelectorAll('.tabs button');
             const tabSections = document.querySelectorAll('.tab-content');

--- a/src/pages/prices/index.astro
+++ b/src/pages/prices/index.astro
@@ -2,6 +2,7 @@
 import "../../styles/global.css";
 import Footer from "../../components/Footer.astro";
 import skus from "../../data/skus.json";
+import { safeBreak } from "../../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
 
 let data;
@@ -45,13 +46,13 @@ const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
         </div>
       )}
       <a href="./" class="small">← トップ</a>
-      <h1>今日の最安“候補”</h1>
-      <p class="small">対象カテゴリから毎日、自動で候補を抽出し、価格とポイント相当を目安に並べ替えています。</p>
-      <p class="small">表示価格は取得時点の参考値です。購入前に必ずリンク先の最新情報をご確認ください。</p>
+      <h1 set:html={safeBreak("今日の最安“候補”")}></h1>
+      <p class="small jp-copy">対象カテゴリから毎日、自動で候補を抽出し、価格とポイント相当を目安に並べ替えています。</p>
+      <p class="small jp-copy">表示価格は取得時点の参考値です。購入前に必ずリンク先の最新情報をご確認ください。</p>
       {data ? (
         <>
-          <p class="small">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
-          {data.sourceStatus && <p class="small">対象ストア: 楽天市場、Yahoo!ショッピング</p>}
+          <p class="small jp-copy">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
+          {data.sourceStatus && <p class="small jp-copy">対象ストア: 楽天市場、Yahoo!ショッピング</p>}
           <ul>
             {data.items.map(it => (
               <li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,6 +45,10 @@ body {
   color: var(--fg-default);
   font: 16px/1.6 system-ui, Segoe UI, Meiryo, sans-serif;
   overflow-x: clip;
+  word-break: normal;
+  line-break: strict;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
 }
 
 :focus-visible {
@@ -117,6 +121,19 @@ h1,
 h2 {
   line-height: 1.2;
   color: var(--fg-strong);
+  text-wrap: balance;
+  line-break: strict;
+  word-break: normal;
+}
+
+.nobr {
+  white-space: nowrap;
+}
+
+@supports (word-break: auto-phrase) {
+  .jp-copy {
+    word-break: auto-phrase;
+  }
 }
 
 .small {


### PR DESCRIPTION
## Summary
- tweak global typography to favour balanced headings and strict line breaking, plus utility classes for copy that should not wrap
- add a `safeBreak` helper that injects `<wbr>` and `.nobr` spans around units and key phrases to prevent awkward splits
- apply the helper and new copy classes across pages so key titles, descriptions, and notices wrap naturally

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce567a779c83268aca8318186bf696