### PR TITLE
Fix best price card label for today's lowest

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -204,7 +204,7 @@ export function getStaticPaths() {
             <h2 set:html={safeBreak("最安情報")}></h2>
             <div class="best-price-cards">
               <section class="best-price-card" role="region" aria-labelledby="best-today-heading">
-                <p class="best-price-card__label" id="best-today-heading">推奨最安（ブランド一致）</p>
+                <p class="best-price-card__label" id="best-today-heading">今日の最安</p>
                 {bestTodayCard ? (
                   <>
                     <p class="best-price-card__line best-price-card__line--primary">


### PR DESCRIPTION
## Summary
- update the first best price card label on the SKU price page to display 今日の最安

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceada49a8883268fd427fb0bdaab4c