### PR TITLE
refactor safe break handling

### DIFF
--- a/src/lib/safe-break.ts
+++ b/src/lib/safe-break.ts
@@ -1,3 +1,6 @@
+const UNIT_PATTERN = /(\d+(?:[.,]\d+)?)(\s*)(GB|TB|MB|円|％|%)/gi;
+const DASH_PATTERN = /\s\u2013\s/g;
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -7,30 +10,165 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
-function normalizeUnitMatch(num: string, spaces: string, unit: string): string {
-  const preservedSpaces = spaces
-    .replace(/ /g, '&nbsp;')
-    .replace(/\u3000/g, '　');
-  return `<span class="nobr">${num}${preservedSpaces}${unit}</span>`;
+function normalizeUnitMatch(num: string, _spaces: string, unit: string): string {
+  return `<span class="nobr">${num}&nbsp;${unit}</span>`;
+}
+
+function applyUnitAndDashRules(html: string): string {
+  return html
+    .replace(UNIT_PATTERN, (_, num: string, spaces: string, unit: string) =>
+      normalizeUnitMatch(num, spaces, unit)
+    )
+    .replace(DASH_PATTERN, () => '<wbr>&nbsp;&ndash;&nbsp;');
+}
+
+function applySafeBreakCharacters(html: string): string {
+  return html.replace(/([・／\u3000])(?!<wbr>)/g, (_, char: string) => `${char}<wbr>`);
+}
+
+function isInsideHtmlEntity(text: string, index: number): boolean {
+  const lastAmp = text.lastIndexOf('&', index - 1);
+  if (lastAmp === -1) {
+    return false;
+  }
+  const nextSemi = text.indexOf(';', lastAmp);
+  return nextSemi !== -1 && nextSemi >= index;
+}
+
+function shouldInsertWordBreak(
+  text: string,
+  prevSegment: Intl.SegmentData,
+  nextSegment: Intl.SegmentData
+): boolean {
+  const boundaryIndex = prevSegment.index + prevSegment.segment.length;
+  if (boundaryIndex <= 0 || boundaryIndex >= text.length) {
+    return false;
+  }
+
+  if (isInsideHtmlEntity(text, boundaryIndex)) {
+    return false;
+  }
+
+  const prevChar = prevSegment.segment.slice(-1);
+  const nextChar = nextSegment.segment.slice(0, 1);
+
+  if (!prevChar || !nextChar) {
+    return false;
+  }
+
+  if (/\s/.test(prevChar) || /\s/.test(nextChar)) {
+    return false;
+  }
+
+  if (/[、。，．・：；！？!?,.;:）］｝〉》」』\)\]\}>]/.test(prevChar)) {
+    return false;
+  }
+
+  if (/[（［｛〈《「『\(\[\{<]/.test(nextChar)) {
+    return false;
+  }
+
+  return true;
+}
+
+function insertWordBreaks(text: string, segmenter: Intl.Segmenter): string {
+  const segments = Array.from(segmenter.segment(text));
+  if (segments.length <= 1) {
+    return text;
+  }
+
+  let result = '';
+  for (let i = 0; i < segments.length; i += 1) {
+    const segment = segments[i];
+    result += segment.segment;
+
+    if (i === segments.length - 1) {
+      continue;
+    }
+
+    const nextSegment = segments[i + 1];
+    if (shouldInsertWordBreak(text, segment, nextSegment)) {
+      result += '<wbr>';
+    }
+  }
+
+  return result;
+}
+
+function applyIntlSegmenter(html: string): string {
+  if (typeof Intl === 'undefined' || typeof Intl.Segmenter === 'undefined') {
+    return html;
+  }
+
+  let segmenter: Intl.Segmenter;
+  try {
+    segmenter = new Intl.Segmenter('ja', { granularity: 'word' });
+  } catch (error) {
+    return html;
+  }
+
+  const tagPattern = /<[^>]+>/g;
+  const stack: Array<{ tag: string; isNobr: boolean }> = [];
+  let result = '';
+  let lastIndex = 0;
+
+  const appendText = (text: string) => {
+    if (!text) {
+      return;
+    }
+    if (stack.some((item) => item.isNobr)) {
+      result += text;
+      return;
+    }
+    result += insertWordBreaks(text, segmenter);
+  };
+
+  let match: RegExpExecArray | null;
+  while ((match = tagPattern.exec(html))) {
+    const text = html.slice(lastIndex, match.index);
+    appendText(text);
+
+    const tag = match[0];
+    result += tag;
+
+    if (/^<\//.test(tag)) {
+      const tagName = tag.replace(/^<\/(\w+)[^>]*>$/, '$1').toLowerCase();
+      for (let i = stack.length - 1; i >= 0; i -= 1) {
+        if (stack[i].tag === tagName) {
+          stack.splice(i, 1);
+          break;
+        }
+      }
+    } else if (/^<!--/.test(tag)) {
+      // Ignore comments
+    } else {
+      const isSelfClosing = /\/>$/.test(tag) || /^<wbr\b/i.test(tag);
+      const tagNameMatch = /^<([a-zA-Z0-9:-]+)/.exec(tag);
+      const tagName = tagNameMatch ? tagNameMatch[1].toLowerCase() : '';
+      const isNobr = /class\s*=\s*["']?[^"'>]*\bnobr\b/i.test(tag);
+
+      if (!isSelfClosing && tagName) {
+        stack.push({ tag: tagName, isNobr: isNobr || tagName === 'nobr' });
+      }
+    }
+
+    lastIndex = tagPattern.lastIndex;
+  }
+
+  appendText(html.slice(lastIndex));
+
+  return result;
 }
 
 function applySafeBreaks(html: string): string {
   let result = html;
 
-  result = result.replace(/(\d+(?:[\.,]\d+)?)(\s*)([GTM]B)/gi, (_, num, spaces, unit) =>
-    normalizeUnitMatch(num, spaces, unit)
-  );
+  result = applyUnitAndDashRules(result);
+  result = applySafeBreakCharacters(result);
+  result = result.replace(/<wbr>$/g, '');
+  result = applyIntlSegmenter(result);
 
-  result = result.replace(/\s–\s/g, () => '<wbr>&nbsp;&ndash;&nbsp;');
-
-  result = result.replace(/価格一覧/g, '<span class="nobr">価格一覧</span>');
-
-  result = result
-    .replace(/・(?!<wbr>)/g, '・<wbr>')
-    .replace(/／(?!<wbr>)/g, '／<wbr>')
-    .replace(/　(?!<wbr>)/g, '　<wbr>');
-
-  return result.replace(/<wbr>$/g, '');
+  return result;
 }
 
 export function safeBreak(title: string): string {
@@ -41,4 +179,3 @@ export function safeBreak(title: string): string {
   const escaped = escapeHtml(title);
   return applySafeBreaks(escaped);
 }
-

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -118,7 +118,11 @@ a:active {
 }
 
 h1,
-h2 {
+h2,
+h3,
+h4,
+h5,
+h6 {
   line-height: 1.2;
   color: var(--fg-strong);
   text-wrap: balance;


### PR DESCRIPTION
## Summary
- refactor safe-break logic to drop fixed phrase dictionary, add unit and punctuation guards, and integrate Intl.Segmenter word breaks when available
- keep punctuation-based <wbr> hints while skipping protected .nobr segments and HTML tags
- extend heading typography rules so all heading levels opt into balanced wrapping with strict line breaking

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceadb1af008326a6ae6cee63c00251