### PR TITLE
Hide chart debug output behind query flag

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -432,7 +432,7 @@ export function getStaticPaths() {
             <canvas id="chart" class="chart" data-sku={sku}></canvas>
           </div>
           <p id="chart-msg" class="small"></p>
-          <pre id="chart-debug" class="small" style="display:none" aria-live="polite"></pre>
+          <pre id="chart-debug" class="small" aria-live="polite"></pre>
           <p class="small jp-copy">過去データはAPI仕様・収集失敗で欠損する場合があります。</p>
           <script>
             const tabButtons = document.querySelectorAll('.tabs button');
@@ -479,9 +479,15 @@ export function getStaticPaths() {
               const canvas = document.getElementById('chart');
               const msg = document.getElementById('chart-msg');
               const debug = document.getElementById('chart-debug');
+              const search = typeof window?.location?.search === 'string'
+                ? window.location.search
+                : '';
+              const isDebugMode = search
+                ? new URLSearchParams(search).get('dbg') === '1'
+                : false;
 
               if (debug) {
-                debug.style.setProperty('display', 'block', 'important');
+                debug.style.setProperty('display', isDebugMode ? 'block' : '');
               }
 
               if (!canvas || !msg) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -146,6 +146,13 @@ h6 {
   font-weight: 600;
 }
 
+#chart-debug {
+  display: none;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 input,
 select {
   background: var(--control-bg);


### PR DESCRIPTION
## Summary
- hide the chart debug log region by default
- gate the debug output display behind the `dbg=1` query parameter while keeping logging intact
- ensure the debug preformatted block wraps within the viewport when shown

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d02104be108326a1083bfc072db612