### PR TITLE
Fix light chart badge contrast and tooltip label

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -706,7 +706,7 @@ export function getStaticPaths() {
                 const priceText = formatYen(datum.price);
                 tooltip.innerHTML = `
                   <div class="chart-tooltip__date">${dateText}</div>
-                  <div class="chart-tooltip__price">実質 ${priceText}</div>
+                  <div class="chart-tooltip__price">${priceText}</div>
                 `;
                 if (chartWrap && canvas) {
                   const containerRect = chartWrap.getBoundingClientRect();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -88,8 +88,8 @@
     --chart-marker-fill: var(--bg-default);
     --chart-marker-stroke: var(--link);
     --chart-text: var(--fg-muted);
-    --chart-badge-bg: rgba(15, 23, 42, 0.08);
-    --chart-badge-bg: color-mix(in srgb, var(--fg-default) 12%, var(--bg-default) 88%);
+    --chart-badge-bg: rgba(15, 23, 42, 0.16);
+    --chart-badge-bg: color-mix(in srgb, var(--fg-default) 22%, var(--bg-default) 78%);
     --chart-badge-fg: var(--badge-fg);
   }
 }


### PR DESCRIPTION
## Summary
- darken the light theme chart badge background to improve contrast on the "本日 ¥価格" chip
- update the chart tooltip label to drop the "実質" prefix so only the price is shown

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d116cfc20483269b1bf58934377cab