### PR TITLE
feat: switch astro base path by deploy target

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,11 @@
 import { defineConfig } from 'astro/config';
+
+const deployTarget = process.env.PUBLIC_DEPLOY_TARGET;
+const isProd = deployTarget === 'prod';
+
 export default defineConfig({
   site: 'https://panappuom.github.io/calc-hub',
-  base: '/calc-hub',
+  base: isProd ? '/calc-hub/' : '/',
   output: 'static',
   trailingSlash: 'always',   // /calculators/ で出力させる
   srcDir: 'src',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "build:codex": "PUBLIC_DEPLOY_TARGET=prod npm run build",
     "preview": "astro preview",
+    "preview:codex": "PUBLIC_DEPLOY_TARGET=prod npm run preview",
     "pipeline": "node pipelines/run-all.mjs",
     "test": "echo \"no tests yet\" && exit 0",
     "pretest:a11y": "npm run build && node scripts/prepare-lhci-dist.mjs && node scripts/setup-playwright.mjs",


### PR DESCRIPTION
## Summary
- toggle Astro base between "/" and "/calc-hub/" according to PUBLIC_DEPLOY_TARGET
- add Codex preview and build npm scripts for the production base configuration

## Testing
- npm run build
- npm run build:codex
- npm run preview:codex
- curl -I http://localhost:4321/calc-hub/prices/sd_128/


------
https://chatgpt.com/codex/tasks/task_e_68d35b72a5008326a1726e388c6cb769