### PR TITLE
Fix price table headers visibility across devices

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -292,14 +292,14 @@ export function getStaticPaths() {
               <>
                 {hasAllPoints && <button class="sort-toggle">価格順に切替</button>}
                 <table class="price-table">
-                  <thead class="sr-only">
+                  <thead class="sr-only-mobile">
                     <tr>
                       <th id="col-all-store" scope="col">ストア</th>
                       <th id="col-all-shop" scope="col">ショップ</th>
                       <th id="col-all-price" scope="col" data-column="price">価格</th>
                       <th id="col-all-point" scope="col" data-column="points">ポイント</th>
                       <th id="col-all-eff" scope="col" data-column="effective">実質価格<br/><span class="small">（ポイント込み）</span></th>
-                      <th id="col-all-action" scope="col" data-column="action" class="sr-only">ショップで確認</th>
+                      <th id="col-all-action" scope="col" data-column="action" class="sr-only-mobile">ショップで確認</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -367,13 +367,13 @@ export function getStaticPaths() {
               <>
                   {sec.hasPoints && <button class="sort-toggle">価格順に切替</button>}
                   <table class="price-table">
-                    <thead class="sr-only">
+                    <thead class="sr-only-mobile">
                       <tr>
                         <th id={`col-${sec.key}-shop`} scope="col">ショップ</th>
                         <th id={`col-${sec.key}-price`} scope="col" data-column="price">価格</th>
                         <th id={`col-${sec.key}-point`} scope="col" data-column="points">ポイント</th>
                         <th id={`col-${sec.key}-eff`} scope="col" data-column="effective">実質価格<br/><span class="small">（ポイント込み）</span></th>
-                        <th id={`col-${sec.key}-action`} scope="col" data-column="action" class="sr-only">ショップで確認</th>
+                        <th id={`col-${sec.key}-action`} scope="col" data-column="action" class="sr-only-mobile">ショップで確認</th>
                       </tr>
                     </thead>
                     <tbody>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -143,6 +143,21 @@ a:active {
   border: 0;
 }
 
+@media (max-width: 768px) {
+  .sr-only-mobile {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+
 .wrap {
   max-width: var(--wrap-max, 980px);
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- add a mobile-only sr-only utility class to keep table headers visible on desktop
- update price tables to use the new helper so the "ショップで確認" column shows on larger screens while staying accessible on mobile

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d368be254c8326adbd008970384dce