### PR TITLE
Add dynamic top-three badges to price tables

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -684,31 +684,124 @@ export function getStaticPaths() {
             })();
           </script>
           <script>
-            document.querySelectorAll('.price-section').forEach(sec => {
-              const toggle = sec.querySelector('.sort-toggle');
-              const tbody = sec.querySelector('tbody');
-              if (!toggle || !tbody) return;
-              const rows = Array.from(tbody.querySelectorAll('tr'));
-              let byEff = true;
-              function sortRows() {
-                rows
-                  .sort((a, b) => {
-                    const k = byEff ? 'eff' : 'price';
-                    return Number(a.dataset[k]) - Number(b.dataset[k]);
-                  })
-                  .forEach(r => tbody.appendChild(r));
+            (function () {
+              const RANK_LIMIT = 3;
+
+              function getBadgeHost(row) {
+                return (
+                  row.querySelector('td[data-cell="store"]') ||
+                  row.querySelector('td[data-cell="shop"]') ||
+                  row.querySelector('td') ||
+                  null
+                );
               }
-              function updateLabel() {
-                toggle.textContent = byEff ? '価格順に切替' : '実質価格順に切替';
+
+              function clearBadge(row) {
+                const badge = row.querySelector('.rank-badge');
+                if (badge && badge.parentElement) {
+                  badge.parentElement.removeChild(badge);
+                }
               }
-              updateLabel();
-              sortRows();
-              toggle.addEventListener('click', () => {
-                byEff = !byEff;
+
+              function applyBadge(row, rank, basisLabel) {
+                const host = getBadgeHost(row);
+                if (!host) return;
+                let badge = host.querySelector('.rank-badge');
+                if (!badge) {
+                  badge = document.createElement('span');
+                  badge.className = 'rank-badge';
+                  host.insertBefore(badge, host.firstChild || null);
+                }
+                badge.textContent = `${rank}位`;
+                badge.className = `rank-badge rank-badge--${rank}`;
+                const ariaLabel = `ランキング${rank}位（${basisLabel}）`;
+                badge.setAttribute('aria-label', ariaLabel);
+                badge.setAttribute('title', ariaLabel);
+              }
+
+              function getMetricKey(metric) {
+                return metric === 'price' ? 'price' : 'eff';
+              }
+
+              function getMetricLabel(metric) {
+                return metric === 'price' ? '価格' : '実質価格';
+              }
+
+              function updateRankings(section, metric) {
+                const tbody = section.querySelector('tbody');
+                if (!tbody) return;
+                const rows = Array.from(tbody.querySelectorAll('tr')).filter(
+                  row => !row.classList.contains('table-collapse-toggle-row')
+                );
+                const metricKey = getMetricKey(metric);
+                const basisLabel = getMetricLabel(metric);
+                rows.forEach(clearBadge);
+                let processed = 0;
+                let currentRank = 0;
+                let lastValue = null;
+                rows.forEach(row => {
+                  processed += 1;
+                  const raw = Number(row.dataset[metricKey]);
+                  const value = Number.isFinite(raw) ? raw : Number.POSITIVE_INFINITY;
+                  if (lastValue === null) {
+                    currentRank = 1;
+                  } else if (value !== lastValue) {
+                    currentRank = processed;
+                  }
+                  lastValue = value;
+                  if (currentRank <= RANK_LIMIT) {
+                    applyBadge(row, currentRank, basisLabel);
+                  }
+                });
+              }
+
+              document.querySelectorAll('.price-section').forEach(section => {
+                const tbody = section.querySelector('tbody');
+                if (!tbody) return;
+                const rows = Array.from(tbody.querySelectorAll('tr')).filter(
+                  row => !row.classList.contains('table-collapse-toggle-row')
+                );
+                if (!rows.length) {
+                  updateRankings(section, 'eff');
+                  return;
+                }
+
+                const toggle = section.querySelector('.sort-toggle');
+                if (!toggle) {
+                  updateRankings(section, 'eff');
+                  return;
+                }
+
+                let byEff = true;
+                function sortRows() {
+                  rows
+                    .sort((a, b) => {
+                      const key = byEff ? 'eff' : 'price';
+                      return Number(a.dataset[key]) - Number(b.dataset[key]);
+                    })
+                    .forEach(r => tbody.appendChild(r));
+                }
+
+                function updateToggleLabel() {
+                  const labelEff = '実質価格順';
+                  const labelPrice = '価格順';
+                  const target = byEff ? labelPrice : labelEff;
+                  toggle.textContent = `${target}に切替`;
+                  toggle.setAttribute('aria-label', `表示を${target}に切り替え`);
+                }
+
+                updateToggleLabel();
                 sortRows();
-                updateLabel();
+                updateRankings(section, byEff ? 'eff' : 'price');
+
+                toggle.addEventListener('click', () => {
+                  byEff = !byEff;
+                  sortRows();
+                  updateToggleLabel();
+                  updateRankings(section, byEff ? 'eff' : 'price');
+                });
               });
-            });
+            })();
           </script>
           <script>
             document.addEventListener('DOMContentLoaded', () => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -542,6 +542,46 @@ label {
   border-color: rgba(19, 78, 74, 0.4);
 }
 
+.rank-badge {
+  --rank-badge-accent: color-mix(in srgb, var(--fg-default) 40%, transparent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 2px 10px 2px 8px;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--fg-default) 16%, var(--bg-default) 84%);
+  color: var(--fg-strong);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  border: 1px solid color-mix(in srgb, var(--fg-default) 28%, transparent);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.rank-badge::before {
+  content: "";
+  display: inline-block;
+  width: 0.5em;
+  height: 0.5em;
+  border-radius: 9999px;
+  background: var(--rank-badge-accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--bg-default) 40%, transparent);
+}
+
+.rank-badge--1 {
+  --rank-badge-accent: #fbbf24;
+}
+
+.rank-badge--2 {
+  --rank-badge-accent: #94a3b8;
+}
+
+.rank-badge--3 {
+  --rank-badge-accent: #f97316;
+}
+
 .price-table {
   width: 100%;
   border-collapse: collapse;
@@ -609,6 +649,11 @@ label {
 .price-table td[data-cell="store"] {
   white-space: nowrap;
   width: 1%;
+}
+
+.price-table td[data-cell="store"] .rank-badge,
+.price-table td[data-cell="shop"] .rank-badge {
+  margin-right: 8px;
 }
 
 .price-table .shop-name {
@@ -732,6 +777,12 @@ label {
     align-items: start;
   }
 
+  .price-table td[data-cell="shop"] .rank-badge {
+    grid-column: 1 / -1;
+    justify-self: flex-start;
+    margin-right: 0;
+  }
+
   .price-table td[data-cell="shop"]::before {
     margin: 0;
     align-self: start;
@@ -746,8 +797,10 @@ label {
   .price-table td[data-cell="store"] {
     position: static;
     display: flex;
+    flex-direction: column;
     justify-content: flex-start;
-    align-items: center;
+    align-items: flex-start;
+    gap: 6px;
     padding: 0;
     margin-bottom: 4px;
     width: 100%;
@@ -756,6 +809,10 @@ label {
   .price-table td[data-cell="store"]::before {
     content: "";
     display: none;
+  }
+
+  .price-table td[data-cell="store"] .rank-badge {
+    margin-right: 0;
   }
 
   .price-table td[data-cell="store"] .store-badge {


### PR DESCRIPTION
## Summary
- add client-side ranking logic that annotates the current top-three offers per table with accessible badges and updates on sort changes
- style the new ranking badges for desktop and mobile layouts while keeping store/shop cells aligned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3d1172aa48326990fd7eb8043e817