### PR TITLE
Place rank badge in shop cell for all tab

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -689,8 +689,8 @@ export function getStaticPaths() {
 
               function getBadgeHost(row) {
                 return (
-                  row.querySelector('td[data-cell="store"]') ||
                   row.querySelector('td[data-cell="shop"]') ||
+                  row.querySelector('td[data-cell="store"]') ||
                   row.querySelector('td') ||
                   null
                 );


### PR DESCRIPTION
## Summary
- prefer the shop cell when inserting ranking badges in price tables
- ensure the all-stores tab displays its ranking badge inside the shop column like other tabs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3d8e1cbdc8326ae1f4d3b89e212e1