### PR TITLE
Adjust mobile price table toggle behavior

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -540,6 +540,15 @@ export function getStaticPaths() {
                     state = false;
                   }
 
+                  let anchorId = table?.id || section.id || '';
+                  if (!anchorId) {
+                    const generated = `price-section-${(key || '')
+                      .replace(/[^a-z0-9]+/gi, '-')
+                      .replace(/^-+|-+$/g, '') || Math.random().toString(36).slice(2)}`;
+                    section.id = generated;
+                    anchorId = generated;
+                  }
+
                   const ctx = {
                     section,
                     tbody,
@@ -549,6 +558,7 @@ export function getStaticPaths() {
                     state,
                     observer: null,
                     mutating: false,
+                    anchorId,
                   };
 
                   toggle.addEventListener('click', () => {
@@ -556,17 +566,9 @@ export function getStaticPaths() {
                     writeState(ctx.key, ctx.state);
                     applyContext(ctx, mobileQuery.matches);
 
-                    if (!mobileQuery.matches) {
-                      return;
+                    if (ctx.state && ctx.anchorId) {
+                      updateAnchor(ctx.anchorId);
                     }
-
-                    const prefersReducedMotion = window.matchMedia(
-                      '(prefers-reduced-motion: reduce)'
-                    );
-                    const behavior = prefersReducedMotion?.matches ? 'auto' : 'smooth';
-                    requestAnimationFrame(() => {
-                      ctx.toggle.scrollIntoView({ behavior, block: 'center' });
-                    });
                   });
 
                   const observer = new MutationObserver(() => {
@@ -585,6 +587,23 @@ export function getStaticPaths() {
                 .filter(Boolean);
 
               if (!contexts.length) return;
+
+              function updateAnchor(anchor) {
+                if (!anchor) return;
+                const { history, location } = window;
+                if (!history || typeof history.replaceState !== 'function' || !location) {
+                  return;
+                }
+
+                const normalized = anchor.startsWith('#') ? anchor : `#${anchor}`;
+                if (location.hash === normalized) {
+                  return;
+                }
+
+                try {
+                  history.replaceState(history.state, '', normalized);
+                } catch {}
+              }
 
               function applyContext(ctx, isMobile) {
                 const observer = ctx.observer;


### PR DESCRIPTION
## Summary
- keep mobile price table toggle from auto-scrolling so the expanded content remains in view
- assign stable anchors to price sections and update the URL hash via history.replaceState when expanded

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d407494e948326b0c25035c9202e74