### PR TITLE
Adjust mobile price card header layout

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -977,7 +977,9 @@ export function getStaticPaths() {
                 if (!hosts.length) return;
                 const ariaLabel = `ランキング${rank}位（${basisLabel}）`;
                 hosts.forEach(host => {
-                  let badge = host.querySelector('.rank-badge');
+                  let badge = Array.from(host.children || []).find(child =>
+                    child.classList && child.classList.contains('rank-badge')
+                  );
                   if (!badge) {
                     badge = document.createElement('span');
                     badge.className = 'rank-badge';

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -501,7 +501,16 @@ export function getStaticPaths() {
                             <span class={getStoreBadgeClass(it.store)}>{it.store}</span>
                           </td>
                           <td headers="col-all-shop" data-label="ショップ" data-cell="shop">
-                            <span class="shop-name" title={it.shopName}>
+                            <span class="sr-only">ショップ</span>
+                            <div class="price-card-head">
+                              <div class="badges">
+                                <span class={getStoreBadgeClass(it.store)}>{it.store}</span>
+                              </div>
+                              <div class="shop-name" title={it.shopName}>
+                                {it.shopName}
+                              </div>
+                            </div>
+                            <span class="shop-name shop-name--desktop" title={it.shopName}>
                               {it.shopName}
                             </span>
                           </td>
@@ -568,7 +577,14 @@ export function getStaticPaths() {
                         return (
                           <tr data-price={it.price} data-eff={eff}>
                             <td headers={`col-${sec.key}-shop`} data-label="ショップ" data-cell="shop">
-                              <span class="shop-name" title={it.shopName}>
+                              <span class="sr-only">ショップ</span>
+                              <div class="price-card-head">
+                                <div class="badges"></div>
+                                <div class="shop-name" title={it.shopName}>
+                                  {it.shopName}
+                                </div>
+                              </div>
+                              <span class="shop-name shop-name--desktop" title={it.shopName}>
                                 {it.shopName}
                               </span>
                             </td>
@@ -923,36 +939,55 @@ export function getStaticPaths() {
             (function () {
               const RANK_LIMIT = 3;
 
-              function getBadgeHost(row) {
-                return (
-                  row.querySelector('td[data-cell="shop"]') ||
-                  row.querySelector('td[data-cell="store"]') ||
-                  row.querySelector('td') ||
-                  null
-                );
+              function getBadgeHosts(row) {
+                const hosts = [];
+                const headerHost = row.querySelector('.price-card-head .badges');
+                if (headerHost) {
+                  hosts.push(headerHost);
+                }
+                const storeCell = row.querySelector('td[data-cell="store"]');
+                if (storeCell) {
+                  hosts.push(storeCell);
+                } else {
+                  const shopCell = row.querySelector('td[data-cell="shop"]');
+                  if (shopCell) {
+                    hosts.push(shopCell);
+                  }
+                }
+                if (!hosts.length) {
+                  const fallback = row.querySelector('td');
+                  if (fallback) {
+                    hosts.push(fallback);
+                  }
+                }
+                return hosts;
               }
 
               function clearBadge(row) {
-                const badge = row.querySelector('.rank-badge');
-                if (badge && badge.parentElement) {
-                  badge.parentElement.removeChild(badge);
-                }
+                const badges = row.querySelectorAll('.rank-badge');
+                badges.forEach(badge => {
+                  if (badge.parentElement) {
+                    badge.parentElement.removeChild(badge);
+                  }
+                });
               }
 
               function applyBadge(row, rank, basisLabel) {
-                const host = getBadgeHost(row);
-                if (!host) return;
-                let badge = host.querySelector('.rank-badge');
-                if (!badge) {
-                  badge = document.createElement('span');
-                  badge.className = 'rank-badge';
-                  host.insertBefore(badge, host.firstChild || null);
-                }
-                badge.textContent = `${rank}位`;
-                badge.className = `rank-badge rank-badge--${rank}`;
+                const hosts = getBadgeHosts(row);
+                if (!hosts.length) return;
                 const ariaLabel = `ランキング${rank}位（${basisLabel}）`;
-                badge.setAttribute('aria-label', ariaLabel);
-                badge.setAttribute('title', ariaLabel);
+                hosts.forEach(host => {
+                  let badge = host.querySelector('.rank-badge');
+                  if (!badge) {
+                    badge = document.createElement('span');
+                    badge.className = 'rank-badge';
+                    host.insertBefore(badge, host.firstChild || null);
+                  }
+                  badge.textContent = `${rank}位`;
+                  badge.className = `rank-badge rank-badge--${rank}`;
+                  badge.setAttribute('aria-label', ariaLabel);
+                  badge.setAttribute('title', ariaLabel);
+                });
               }
 
               function getMetricKey(metric) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -724,6 +724,10 @@ label {
   word-break: break-word;
 }
 
+.price-card-head {
+  display: none;
+}
+
 .price-table tbody tr:nth-child(even) {
   background: var(--table-row-alt-bg);
 }
@@ -839,54 +843,47 @@ label {
   }
 
   .price-table td[data-cell="shop"] {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    gap: 8px;
-    align-items: start;
-  }
-
-  .price-table td[data-cell="shop"] .rank-badge {
-    grid-column: 1 / -1;
-    justify-self: flex-start;
-    margin-right: 0;
+    display: block;
   }
 
   .price-table td[data-cell="shop"]::before {
-    margin: 0;
-    align-self: start;
-  }
-
-  .price-table td[data-cell="shop"] .shop-name {
-    margin-bottom: 0;
-    text-align: right;
-    justify-self: end;
-  }
-
-  .price-table td[data-cell="store"] {
-    position: static;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    align-items: center;
-    gap: 6px;
-    padding: 0;
-    margin-bottom: 4px;
-    width: 100%;
-  }
-
-  .price-table td[data-cell="store"]::before {
-    content: "";
     display: none;
   }
 
-  .price-table td[data-cell="store"] .rank-badge {
-    margin-right: 0;
+  .price-table td[data-cell="shop"] > .rank-badge {
+    display: none;
   }
 
-  .price-table td[data-cell="store"] .store-badge {
-    max-width: 100%;
-    white-space: normal;
+  .price-table td[data-cell="shop"] > .shop-name--desktop {
+    display: none;
+  }
+
+  .price-card-head {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  .price-card-head .badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .price-card-head .shop-name {
+    display: block;
+    margin: 0;
+    text-align: right;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .price-table td[data-cell="store"] {
+    display: none;
   }
 
   .price-table td[data-cell="action"] {


### PR DESCRIPTION
## Summary
- add a mobile-only price card header that groups ranking and store badges with the shop name
- keep desktop table semantics while moving the shop label to screen-reader only markup
- update ranking badge injection logic and responsive styles to support the new structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d578b60bf48326bf7c27a8f40316f2