### PR TITLE
Add desktop shop cell rank badges for all stores tab

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -1100,14 +1100,25 @@ export function getStaticPaths() {
                   hosts.push(headerHost);
                 }
                 const storeCell = row.querySelector('td[data-cell="store"]');
-                if (storeCell) {
-                  hosts.push(storeCell);
-                } else {
-                  const shopCell = row.querySelector('td[data-cell="shop"]');
-                  if (shopCell) {
+                const shopCell = row.querySelector('td[data-cell="shop"]');
+                const table = row.closest('table');
+                const isAllStoresTable = table && table.id === 'price-table-all';
+
+                if (isAllStoresTable && shopCell) {
+                  const desktopHost = shopCell.querySelector('.shop-name--desktop');
+                  if (desktopHost) {
+                    hosts.push(desktopHost);
+                  } else {
                     hosts.push(shopCell);
                   }
                 }
+
+                if (storeCell) {
+                  hosts.push(storeCell);
+                } else if (shopCell) {
+                  hosts.push(shopCell);
+                }
+
                 if (!hosts.length) {
                   const fallback = row.querySelector('td');
                   if (fallback) {


### PR DESCRIPTION
## Summary
- ensure the ranking badge script also targets the shop cell on the desktop all-stores table so the badge appears like the other tabs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d668da77c4832698653690fb10b3fc