### PR TITLE
Remove desktop store badge from all stores tab

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -498,7 +498,7 @@ export function getStaticPaths() {
                             data-label="ストア"
                             data-cell="store"
                           >
-                            <span class={getStoreBadgeClass(it.store)}>{it.store}</span>
+                            {it.store}
                           </td>
                           <td headers="col-all-shop" data-label="ショップ" data-cell="shop">
                             <span class="sr-only">ショップ</span>


### PR DESCRIPTION
## Summary
- remove the rank badge markup from the All Stores tab's store column so the desktop view no longer shows the badge
- leave the mobile markup and the Rakuten-only / Yahoo-only tabs unchanged

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d66f97d7b08326b211688e18080517