### PR TITLE
Align rank badges with shop names in desktop price tables

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -529,8 +529,10 @@ export function getStaticPaths() {
                                   {it.store}
                                 </span>
                               </div>
-                              <div class="shop-name" title={it.shopName}>
-                                {it.shopName}
+                              <div class="shop-meta">
+                                <span class="shop-name" title={it.shopName}>
+                                  {it.shopName}
+                                </span>
                               </div>
                             </div>
                           </td>
@@ -600,8 +602,10 @@ export function getStaticPaths() {
                               <span class="sr-only">ショップ</span>
                               <div class="price-card-head">
                                 <div class="badges"></div>
-                                <div class="shop-name" title={it.shopName}>
-                                  {it.shopName}
+                                <div class="shop-meta">
+                                  <span class="shop-name" title={it.shopName}>
+                                    {it.shopName}
+                                  </span>
                                 </div>
                               </div>
                             </td>
@@ -1180,6 +1184,10 @@ export function getStaticPaths() {
               const RANK_LIMIT = 3;
 
               function getBadgeHosts(row) {
+                const metaHost = row.querySelector('.price-card-head .shop-meta');
+                if (metaHost) {
+                  return [metaHost];
+                }
                 const headerHost = row.querySelector('.price-card-head .badges');
                 if (headerHost) {
                   return [headerHost];

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -570,18 +570,24 @@ label {
   margin-left: 0;
 }
 
-.store-badge {
+.store-badge,
+.rank-badge {
   display: inline-flex;
   align-items: center;
+  height: 24px;
+  line-height: 1;
+  box-sizing: border-box;
+}
+
+.store-badge {
   justify-content: center;
-  padding: 2px 10px;
+  padding: 0 10px;
   border-radius: 9999px;
   background: var(--control-bg);
   color: var(--badge-fg);
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.04em;
-  line-height: 1.2;
   text-transform: none;
   white-space: nowrap;
   border: 1px solid rgba(255, 255, 255, 0.16);
@@ -601,17 +607,14 @@ label {
 
 .rank-badge {
   --rank-badge-accent: color-mix(in srgb, var(--fg-default) 40%, transparent);
-  display: inline-flex;
-  align-items: center;
   gap: 0.4em;
-  padding: 2px 10px 2px 8px;
+  padding: 0 10px 0 8px;
   border-radius: 9999px;
   background: color-mix(in srgb, var(--fg-default) 16%, var(--bg-default) 84%);
   color: var(--fg-strong);
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.04em;
-  line-height: 1.2;
   border: 1px solid color-mix(in srgb, var(--fg-default) 28%, transparent);
   white-space: nowrap;
   flex-shrink: 0;
@@ -670,7 +673,7 @@ label {
 .price-table td {
   padding: 10px 12px;
   border-bottom: 1px solid var(--border-subtle);
-  vertical-align: top;
+  vertical-align: middle;
 }
 
 .price-table td[data-cell="price"],
@@ -714,15 +717,29 @@ label {
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 4px;
+  margin-bottom: 0;
   line-height: 1.4;
   word-break: break-word;
+}
+
+.shop-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .price-card-head {
   display: flex;
   align-items: flex-start;
   gap: 12px;
+}
+
+.price-card-head .shop-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
 }
 
 .price-card-head .badges {
@@ -733,7 +750,6 @@ label {
 }
 
 .price-card-head .shop-name {
-  flex: 1;
   margin: 0;
 }
 
@@ -869,6 +885,13 @@ label {
     align-items: center;
     gap: 8px;
     margin-bottom: 8px;
+  }
+
+  .price-card-head .shop-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
   }
 
   .price-card-head .badges {


### PR DESCRIPTION
## Summary
- update desktop price table shop cells to wrap rank badges and shop names in a shared flex row
- standardize badge styling and table cell alignment to remove vertical offsets
- adjust ranking badge script to insert into the new shop metadata container

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d80fc872f883268ea049d712fb72a3