### PR TITLE
Align price table badges on desktop

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -708,6 +708,25 @@ label {
   width: 1%;
 }
 
+@media (min-width: 769px) {
+  .price-table .rank-badge,
+  .price-table .store-badge {
+    display: inline-flex;
+    align-items: center;
+    height: 28px;
+    line-height: 1;
+    vertical-align: middle;
+  }
+
+  .price-table td[data-cell="store"],
+  .price-table td[data-cell="shop"] {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    vertical-align: middle;
+  }
+}
+
 .price-table .shop-name {
   display: -webkit-box;
   -webkit-line-clamp: 2;


### PR DESCRIPTION
## Summary
- adjust desktop price table badges to share consistent sizing and vertical alignment
- center-align store and shop cells in the desktop price table for better badge positioning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d969c8c4c08326a0f10ce65edb4319