### PR TITLE
Adjust best price card display for matching offers

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -171,7 +171,7 @@ const tieSourceList = allList.length ? allList : list;
 const tieCount = Number.isFinite(bestTodayEffectiveValue)
   ? tieSourceList.filter(it => getEffectiveValue(it) === bestTodayEffectiveValue).length
   : 0;
-const shouldShowTieLink = bestPriceCase === 'tie' && tieCount > 1 && !isSamePrice;
+const shouldShowTieLink = bestPriceCase === 'tie' && tieCount > 1;
 const showRecommendedCard = hasRecommendedSection && bestPriceCase === 'separate';
 const showPlaceholderCard = hasRecommendedSection && isSamePrice;
 const bestTodayLabel = isSamePrice

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -171,8 +171,12 @@ const tieSourceList = allList.length ? allList : list;
 const tieCount = Number.isFinite(bestTodayEffectiveValue)
   ? tieSourceList.filter(it => getEffectiveValue(it) === bestTodayEffectiveValue).length
   : 0;
-const shouldShowTieLink = bestPriceCase === 'tie' && tieCount > 1;
+const shouldShowTieLink = bestPriceCase === 'tie' && tieCount > 1 && !isSamePrice;
 const showRecommendedCard = hasRecommendedSection && bestPriceCase === 'separate';
+const showPlaceholderCard = hasRecommendedSection && isSamePrice;
+const bestTodayLabel = isSamePrice
+  ? '今日の最安 : 推奨最安（ブランド一致）と同額です。'
+  : '今日の最安';
 
 const bestPriceContext = {
   case: bestPriceCase,
@@ -301,10 +305,7 @@ export function getStaticPaths() {
             <h2 set:html={safeBreak("最安情報")}></h2>
             <div class="best-price-cards" data-bestprice-case={bestPriceCase}>
               <section class="best-price-card" role="region" aria-labelledby="best-today-heading">
-                <p class="best-price-card__label" id="best-today-heading">今日の最安</p>
-                {bestPriceCase === 'merge' && (
-                  <span class="best-price-card__badge" aria-label="推奨最安と同一のため統合表示">推奨最安と一致</span>
-                )}
+                <p class="best-price-card__label" id="best-today-heading">{bestTodayLabel}</p>
                 {bestTodayCard ? (
                   <>
                     <p class="best-price-card__line best-price-card__line--primary">
@@ -334,9 +335,6 @@ export function getStaticPaths() {
                           {bestTodayCard.shopDisplayName} で確認 <span aria-hidden="true">↗</span>
                         </a>
                       </p>
-                    )}
-                    {bestPriceCase === 'merge' && bestRecommendedEvidence && (
-                      <p class="best-price-card__note">{bestRecommendedEvidence}</p>
                     )}
                     {shouldShowTieLink && (
                       <p class="best-price-card__note best-price-card__note--link">
@@ -393,6 +391,8 @@ export function getStaticPaths() {
                     <p class="best-price-card__line best-price-card__line--empty">該当なし</p>
                   )}
                 </section>
+              ) : showPlaceholderCard ? (
+                <section class="best-price-card best-price-card--placeholder" aria-hidden="true"></section>
               ) : null}
             </div>
           </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -302,6 +302,11 @@ label {
   position: relative;
 }
 
+.best-price-card--placeholder {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .best-price-card:focus-within {
   border-color: var(--border-strong);
   box-shadow: 0 0 0 1px var(--border-strong);


### PR DESCRIPTION
## Summary
- update the best price card label and remove the badge/note when the recommended offer matches today's best price
- add a placeholder card to keep the layout consistent when only one card is visible and document it with new styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbef3e697c8326bfbb35854d6d1b6e