### PR TITLE
Add affiliate link builder for deals page

### DIFF
--- a/data/affiliate.json
+++ b/data/affiliate.json
@@ -1,0 +1,14 @@
+{
+  "rakuten.co.jp": {
+    "append": {
+      "scid": "af_calc-hub",
+      "utm_source": "calc-hub",
+      "utm_medium": "deals"
+    }
+  },
+  "amazon.co.jp": {
+    "append": {
+      "tag": "calchub-22"
+    }
+  }
+}

--- a/scripts/link-builder.mjs
+++ b/scripts/link-builder.mjs
@@ -1,0 +1,77 @@
+import affiliateConfig from "../data/affiliate.json" assert { type: "json" };
+
+const DEFAULT_TARGET = "_blank";
+const DEFAULT_REL = "sponsored noopener";
+
+const normalizedRules = Object.entries(affiliateConfig ?? {}).map(([domain, rule]) => ({
+  domain: domain.toLowerCase(),
+  rule: rule ?? {}
+}));
+
+function findRuleForHost(hostname) {
+  const host = (hostname ?? "").toLowerCase();
+  if (!host) {
+    return null;
+  }
+  for (const { domain, rule } of normalizedRules) {
+    if (host === domain || host.endsWith(`.${domain}`)) {
+      return rule;
+    }
+  }
+  return null;
+}
+
+function applyAppendParams(url, params) {
+  if (!params || typeof params !== "object") {
+    return;
+  }
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    url.searchParams.set(key, String(value));
+  }
+}
+
+export function buildAffiliateHref(rawUrl) {
+  if (!rawUrl || typeof rawUrl !== "string") {
+    return rawUrl;
+  }
+
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
+
+  const rule = findRuleForHost(url.hostname);
+  if (!rule) {
+    return url.toString();
+  }
+
+  if (rule.append) {
+    applyAppendParams(url, rule.append);
+  }
+
+  if (rule.replaceHost) {
+    url.hostname = rule.replaceHost;
+  }
+
+  if (rule.protocol) {
+    url.protocol = rule.protocol;
+  }
+
+  return url.toString();
+}
+
+export function buildLink(rawUrl) {
+  const href = buildAffiliateHref(rawUrl);
+  return {
+    href,
+    target: DEFAULT_TARGET,
+    rel: DEFAULT_REL
+  };
+}
+
+export default buildLink;

--- a/src/pages/deals.astro
+++ b/src/pages/deals.astro
@@ -3,6 +3,7 @@ import "../styles/global.css";
 import Footer from "../components/Footer.astro";
 import data from "../data/deals.json";
 import { safeBreak } from "../lib/safe-break";
+import { buildLink } from "../../scripts/link-builder.mjs";
 const BASE_URL = import.meta.env.BASE_URL;
 const items = (data?.items ?? []).slice(0, 100);
 const dtf = new Intl.DateTimeFormat("ja-JP", {
@@ -34,31 +35,34 @@ function fmt(value){
       <h1 set:html={safeBreak("今日のセール・割引まとめ")}></h1>
       <p class="small jp-copy">主要サイトの公式情報から毎日自動で集めています。ノイズ（求人・PR等）は除外。</p>
       <div class="grid" style="margin-top:8px">
-        {items.map((it) => (
-          <a
-            class="card"
-            href={it.url}
-            target="_blank"
-            rel="nofollow noopener"
-            title={`${it.source}で詳細を確認できます（新しいタブが開きます）`}
-          >
-            <h2 style="margin:0 0 6px 0" set:html={safeBreak(it.title)}></h2>
-            <p class="small jp-copy" style="margin:0 0 6px 0">{it.source} / {fmt(it.publishedAt)}</p>
-            {it.tags?.length > 0 && (
-              <ul class="tag-list small" aria-label="タグ" style="margin:0 0 6px 0; padding:0; display:flex; flex-wrap:wrap; gap:4px; list-style:none;">
-                {it.tags.map((tag) => (
-                  <li
-                    class="tag-chip"
-                    style="background:#f1f5f9; color:#0f172a; border-radius:12px; padding:2px 8px;"
-                  >
-                    {tag}
-                  </li>
-                ))}
-              </ul>
-            )}
-            {it.summary && <p class="jp-copy" style="margin:0">{it.summary}</p>}
-          </a>
-        ))}
+        {items.map((it) => {
+          const link = buildLink(it.url);
+          return (
+            <a
+              class="card"
+              href={link.href}
+              target={link.target}
+              rel={link.rel}
+              title={`${it.source}で詳細を確認できます（新しいタブが開きます）`}
+            >
+              <h2 style="margin:0 0 6px 0" set:html={safeBreak(it.title)}></h2>
+              <p class="small jp-copy" style="margin:0 0 6px 0">{it.source} / {fmt(it.publishedAt)}</p>
+              {it.tags?.length > 0 && (
+                <ul class="tag-list small" aria-label="タグ" style="margin:0 0 6px 0; padding:0; display:flex; flex-wrap:wrap; gap:4px; list-style:none;">
+                  {it.tags.map((tag) => (
+                    <li
+                      class="tag-chip"
+                      style="background:#f1f5f9; color:#0f172a; border-radius:12px; padding:2px 8px;"
+                    >
+                      {tag}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {it.summary && <p class="jp-copy" style="margin:0">{it.summary}</p>}
+            </a>
+          );
+        })}
       </div>
       <p class="small jp-copy" style="margin-top:8px">価格・在庫は変動します。最新情報はリンク先でご確認ください。</p>
     </div>


### PR DESCRIPTION
## Summary
- add an affiliate rules configuration and reusable link builder
- update the deals page to output sponsored links that respect the allowlist

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de901dedf88326ab72d1d00c2b8063