### PR TITLE
Add ItemList NewsArticle structured data to deals page

### DIFF
--- a/src/pages/deals.astro
+++ b/src/pages/deals.astro
@@ -117,26 +117,46 @@ const dealsStructuredData = {
   numberOfItems: enrichedItems.length,
   itemListElement: enrichedItems.map((item, index) => {
     const url = item.link?.href ?? item.url ?? '';
-    const article = {
-      '@type': 'NewsArticle',
-      name: item.title ?? '',
-      headline: item.title ?? '',
-      url
-    };
+    const hasNewsArticleRequirements = Boolean(
+      item.image && item.source && item.publishedAt
+    );
+
+    const article = hasNewsArticleRequirements
+      ? {
+          '@type': 'NewsArticle',
+          name: item.title ?? '',
+          headline: item.title ?? '',
+          url,
+          datePublished: item.publishedAt,
+          image: item.image,
+          author: {
+            '@type': 'Organization',
+            name: item.source
+          },
+          publisher: {
+            '@type': 'Organization',
+            name: item.source
+          }
+        }
+      : {
+          '@type': 'WebPage',
+          name: item.title ?? '',
+          url
+        };
 
     if (item.summary) {
       article.description = item.summary;
     }
 
-    if (item.publishedAt) {
+    if (item.publishedAt && !article.datePublished) {
       article.datePublished = item.publishedAt;
     }
 
-    if (item.image) {
+    if (item.image && !article.image) {
       article.image = item.image;
     }
 
-    if (item.source) {
+    if (item.source && !article.publisher) {
       article.publisher = {
         '@type': 'Organization',
         name: item.source

--- a/src/pages/deals.astro
+++ b/src/pages/deals.astro
@@ -116,27 +116,40 @@ const dealsStructuredData = {
   url: canonicalUrl,
   numberOfItems: enrichedItems.length,
   itemListElement: enrichedItems.map((item, index) => {
-    const entry = {
-      '@type': 'ListItem',
-      position: index + 1,
-      url: item.link?.href ?? item.url ?? '',
-      name: item.title ?? ''
+    const url = item.link?.href ?? item.url ?? '';
+    const article = {
+      '@type': 'NewsArticle',
+      name: item.title ?? '',
+      headline: item.title ?? '',
+      url
     };
 
     if (item.summary) {
-      entry.description = item.summary;
+      article.description = item.summary;
     }
 
     if (item.publishedAt) {
-      entry.datePublished = item.publishedAt;
+      article.datePublished = item.publishedAt;
+    }
+
+    if (item.image) {
+      article.image = item.image;
     }
 
     if (item.source) {
-      entry.publisher = {
+      article.publisher = {
         '@type': 'Organization',
         name: item.source
       };
     }
+
+    const entry = {
+      '@type': 'ListItem',
+      position: index + 1,
+      url,
+      name: item.title ?? '',
+      item: article
+    };
 
     if (item.tags?.length) {
       entry.keywords = item.tags.join(', ');


### PR DESCRIPTION
## Summary
- add ItemList structured data with NewsArticle entries on the deals page to support SEO rich results

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe4dc38c08326b3c73c866773703b