### PR TITLE
Add Plausible analytics instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,26 @@
 
 - ローカル開発では `npm run pretest:a11y` を実行すると、ビルドと Lighthouse 用の準備に加えて Playwright 経由で Chromium が取得されます。続けて `npm run test:a11y` を実行してください。
 - GitHub Actions 上では `browser-actions/setup-chromium` が Chromium を提供するため、Playwright からのダウンロードは行われません。
+
+## アクセス解析の有効化
+
+Plausible を利用した Cookie レス計測をサポートしています。計測を有効化するには以下の公開環境変数を設定してください。
+
+```
+PUBLIC_ANALYTICS_PROVIDER=plausible
+PUBLIC_ANALYTICS_DOMAIN=<your-plausible-domain>
+# 任意: 独自ホストしたスクリプトを使う場合のみ
+PUBLIC_ANALYTICS_SRC=https://plausible.io/js/script.js
+```
+
+`PUBLIC_ANALYTICS_PROVIDER` を `none`（既定値）にすると計測は無効化され、スクリプトは読み込まれません。
+
+### 送信イベント一覧
+
+| イベント名 | 発火タイミング | 送信プロパティ |
+| --- | --- | --- |
+| `deal_click` | `/deals/` のカードリンクをクリックしたとき | `url`, `source_domain`, `tags`（CSV）, `position`, `utm_source`, `utm_medium`, `utm_campaign` |
+| `sku_card_click` | `/prices/` で SKU カードをクリックしたとき | `sku`, `rank`, `from_page` |
+| `price_click` | `/prices/[sku]/` の「ショップで確認」ボタンをクリックしたとき | `sku`, `store`, `shop_name`, `price`, `effective_price`, `utm_source`, `utm_medium`, `utm_campaign` |
+
+`PUBLIC_ANALYTICS_PROVIDER=plausible` が設定されていれば、各イベントは `window.plausible()` を通じて送信されます。

--- a/scripts/run-deals-qa.mjs
+++ b/scripts/run-deals-qa.mjs
@@ -163,7 +163,11 @@ const evaluation = await page.evaluate(() => {
     }
   }
 
+  const analyticsScript = document.querySelector('script[data-domain][src]');
+  const analyticsEnabled = Boolean(analyticsScript);
+
   const plausibleCalls = [];
+  const originalPlausible = window.plausible;
   window.plausible = (...args) => {
     plausibleCalls.push(args);
   };
@@ -172,12 +176,14 @@ const evaluation = await page.evaluate(() => {
   if (firstLink) {
     firstLink.addEventListener('click', (event) => event.preventDefault(), { once: true });
     firstLink.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-    if (!plausibleCalls.length) {
+    if (analyticsEnabled && !plausibleCalls.length) {
       analyticsIssues.push('window.plausible was not called when clicking the first deal card.');
     }
   } else {
     analyticsIssues.push('No deal links found for analytics verification.');
   }
+
+  window.plausible = originalPlausible;
 
   return {
     relIssues,

--- a/src/components/AnalyticsRuntime.astro
+++ b/src/components/AnalyticsRuntime.astro
@@ -1,0 +1,29 @@
+<script type="module">
+  import { send } from '../lib/analytics';
+
+  const parsePayload = (value) => {
+    if (!value) return undefined;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  };
+
+  const attach = (element) => {
+    if (!element) return;
+    if (element.dataset.analyticsBound === '1') return;
+    element.addEventListener('click', () => {
+      const eventName = element.getAttribute('data-analytics');
+      if (!eventName) {
+        return;
+      }
+      const payload = parsePayload(element.getAttribute('data-analytics-payload'));
+      send(eventName, payload);
+    });
+    element.dataset.analyticsBound = '1';
+  };
+
+  const elements = Array.from(document.querySelectorAll('[data-analytics]'));
+  elements.forEach((element) => attach(element));
+</script>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,11 @@
 /// <reference path="../.astro/types.d.ts" />
+
+interface ImportMetaEnv {
+  readonly PUBLIC_ANALYTICS_PROVIDER?: 'plausible' | 'none';
+  readonly PUBLIC_ANALYTICS_DOMAIN?: string;
+  readonly PUBLIC_ANALYTICS_SRC?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,60 @@
+const DEFAULT_PROVIDER = 'none';
+const DEFAULT_SCRIPT_SRC = 'https://plausible.io/js/script.js';
+
+const provider = (import.meta.env.PUBLIC_ANALYTICS_PROVIDER ?? DEFAULT_PROVIDER).toLowerCase();
+const domain = (import.meta.env.PUBLIC_ANALYTICS_DOMAIN ?? '').trim();
+const scriptSrc = (import.meta.env.PUBLIC_ANALYTICS_SRC ?? DEFAULT_SCRIPT_SRC).trim() || DEFAULT_SCRIPT_SRC;
+
+export type AnalyticsProps = Record<string, string | number | boolean>;
+
+export function getAnalyticsScriptConfig() {
+  if (provider !== 'plausible') {
+    return null;
+  }
+  if (!domain) {
+    return null;
+  }
+  return {
+    src: scriptSrc,
+    domain,
+  };
+}
+
+export function isAnalyticsEnabled() {
+  return provider === 'plausible' && Boolean(domain);
+}
+
+export function send(eventName: string, props?: AnalyticsProps) {
+  if (!eventName || typeof eventName !== 'string') {
+    return;
+  }
+  if (provider !== 'plausible') {
+    return;
+  }
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    const plausible = window.plausible;
+    if (typeof plausible !== 'function') {
+      return;
+    }
+    plausible(eventName, props ? { props } : undefined);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[analytics] failed to send event', error);
+    }
+  }
+}
+
+declare global {
+  interface Window {
+    plausible?: (eventName: string, options?: { props?: AnalyticsProps }) => void;
+  }
+}
+
+export default {
+  getAnalyticsScriptConfig,
+  isAnalyticsEnabled,
+  send,
+};

--- a/src/pages/about/affiliate.astro
+++ b/src/pages/about/affiliate.astro
@@ -1,8 +1,11 @@
 ---
 import "../../styles/global.css";
+import AnalyticsRuntime from "../../components/AnalyticsRuntime.astro";
 import Footer from "../../components/Footer.astro";
+import { getAnalyticsScriptConfig } from "../../lib/analytics";
 import { safeBreak } from "../../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
+const analyticsScript = getAnalyticsScriptConfig();
 ---
 <html lang="ja">
   <head>
@@ -10,6 +13,9 @@ const BASE_URL = import.meta.env.BASE_URL;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <base href={BASE_URL} />
     <title>アフィリエイトについて</title>
+    {analyticsScript && (
+      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
+    )}
   </head>
   <body>
     <div class="wrap">
@@ -19,7 +25,9 @@ const BASE_URL = import.meta.env.BASE_URL;
       <p class="jp-copy">紹介料は商品価格やお客様の負担に影響しません。</p>
       <p class="jp-copy">本サイトの掲載順・評価は、取得時点の情報（価格・在庫・仕様）と独自ルール（ノイズ除外など）に基づきます。</p>
       <p class="jp-copy">購入の最終判断は、必ずリンク先の最新情報をご確認ください。</p>
+      <p class="small jp-copy">サイトの利用状況はCookieレス分析ツール（Plausible）で匿名集計しています。</p>
     </div>
     <Footer />
+    <AnalyticsRuntime />
   </body>
 </html>

--- a/src/pages/about/sources.astro
+++ b/src/pages/about/sources.astro
@@ -1,8 +1,11 @@
 ---
 import "../../styles/global.css";
+import AnalyticsRuntime from "../../components/AnalyticsRuntime.astro";
 import Footer from "../../components/Footer.astro";
+import { getAnalyticsScriptConfig } from "../../lib/analytics";
 import { safeBreak } from "../../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
+const analyticsScript = getAnalyticsScriptConfig();
 ---
 <html lang="ja">
   <head>
@@ -10,6 +13,9 @@ const BASE_URL = import.meta.env.BASE_URL;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <base href={BASE_URL} />
     <title>データ出典と更新について</title>
+    {analyticsScript && (
+      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
+    )}
   </head>
   <body>
     <div class="wrap">
@@ -26,5 +32,6 @@ const BASE_URL = import.meta.env.BASE_URL;
       <p class="small jp-copy">解析や取得方法など技術的な詳細は予告なく調整される場合があります。</p>
     </div>
     <Footer />
+    <AnalyticsRuntime />
   </body>
 </html>

--- a/src/pages/deals.astro
+++ b/src/pages/deals.astro
@@ -1,13 +1,16 @@
 ---
 import "../styles/global.css";
+import AnalyticsRuntime from "../components/AnalyticsRuntime.astro";
 import Footer from "../components/Footer.astro";
 import data from "../data/deals.json";
 import rssSources from "../../data-sources/rss.json";
+import { getAnalyticsScriptConfig } from "../lib/analytics";
 import { safeBreak } from "../lib/safe-break";
 import { buildLink } from "../../scripts/link-builder.mjs";
 
 const BASE_URL = import.meta.env.BASE_URL;
 const items = (data?.items ?? []).slice(0, 100);
+const analyticsScript = getAnalyticsScriptConfig();
 
 const dtf = new Intl.DateTimeFormat("ja-JP", {
   timeZone: "Asia/Tokyo",
@@ -81,6 +84,36 @@ function toTimestamp(value) {
   const t = d.getTime();
   if (Number.isNaN(t)) return Date.now();
   return t;
+}
+
+function toAnalyticsPayload(item, index, tagList) {
+  const payload = {
+    url: item.link?.href ?? item.url ?? "",
+    source_domain: "",
+    tags: tagList.join(","),
+    position: index + 1,
+  };
+
+  try {
+    const url = new URL(item.url ?? item.link?.href ?? "");
+    payload.source_domain = url.hostname ?? "";
+  } catch {
+    payload.source_domain = "";
+  }
+
+  try {
+    const trackingUrl = new URL(item.link?.href ?? "");
+    const source = trackingUrl.searchParams.get("utm_source");
+    const medium = trackingUrl.searchParams.get("utm_medium");
+    const campaign = trackingUrl.searchParams.get("utm_campaign");
+    if (source) payload.utm_source = source;
+    if (medium) payload.utm_medium = medium;
+    if (campaign) payload.utm_campaign = campaign;
+  } catch {
+    /* noop */
+  }
+
+  return JSON.stringify(payload);
 }
 
 const DAY_MS = 1000 * 60 * 60 * 24;
@@ -188,6 +221,9 @@ const dealsSchemaJson = JSON.stringify(dealsStructuredData, null, 2);
     <base href={BASE_URL} />
     <title>今日のセール・割引まとめ</title>
     <script type="application/ld+json" data-schema="deal-list" set:html={dealsSchemaJson}></script>
+    {analyticsScript && (
+      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
+    )}
   </head>
   <body>
     <div class="wrap">
@@ -227,8 +263,9 @@ const dealsSchemaJson = JSON.stringify(dealsStructuredData, null, 2);
       <p class="small jp-copy" data-deal-count>{`全${enrichedItems.length}件`}</p>
 
       <ul class="deal-list" data-deal-list>
-        {enrichedItems.map((it) => {
+        {enrichedItems.map((it, index) => {
           const tagList = (it.tags ?? []).filter(Boolean);
+          const analyticsPayload = toAnalyticsPayload(it, index, tagList);
           return (
             <li
               class="deal-list__item"
@@ -242,6 +279,8 @@ const dealsSchemaJson = JSON.stringify(dealsStructuredData, null, 2);
                 target={it.link.target}
                 rel={it.link.rel}
                 title={`${it.source}で詳細を確認できます（新しいタブが開きます）`}
+                data-analytics="deal_click"
+                data-analytics-payload={analyticsPayload}
               >
                 <div class="deal-card__header">
                   <div class="deal-card__badge-row">
@@ -358,5 +397,6 @@ const dealsSchemaJson = JSON.stringify(dealsStructuredData, null, 2);
       </script>
     </div>
     <Footer />
+    <AnalyticsRuntime />
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,11 @@
 ---
 import "../styles/global.css";
 import Footer from "../components/Footer.astro";
+import AnalyticsRuntime from "../components/AnalyticsRuntime.astro";
+import { getAnalyticsScriptConfig } from "../lib/analytics";
 import { safeBreak } from "../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
+const analyticsScript = getAnalyticsScriptConfig();
 const tools = [
   {
     href: "calculators/",
@@ -30,6 +33,9 @@ const tools = [
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <base href={BASE_URL} />
     <title>なんでも計算室＆お得チェッカー</title>
+    {analyticsScript && (
+      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
+    )}
   </head>
   <body>
     <div class="wrap">
@@ -48,5 +54,6 @@ const tools = [
       </div>
     </div>
     <Footer />
+    <AnalyticsRuntime />
   </body>
 </html>

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -1,11 +1,14 @@
 ---
 import "../../styles/global.css";
+import AnalyticsRuntime from "../../components/AnalyticsRuntime.astro";
 import Footer from "../../components/Footer.astro";
 import skus from "../../data/skus.json";
+import { getAnalyticsScriptConfig } from "../../lib/analytics";
 import { safeBreak } from "../../lib/safe-break";
 const IS_DEV = import.meta.env.DEV;
 const BASE_URL = import.meta.env.BASE_URL;
 const clientGlobalsScript = `window.__APP_DEV__ = ${JSON.stringify(IS_DEV)};\nwindow.__BASE_URL__ = ${JSON.stringify(BASE_URL)};`;
+const analyticsScript = getAnalyticsScriptConfig();
 
 let data;
 let rakutenData;
@@ -155,6 +158,8 @@ if (bestRecommended) {
 }
 const bestTodayCard = getPriceCardModel(bestToday, { prefix: '最安' });
 const bestRecommendedCard = getPriceCardModel(bestRecommended, { prefix: '推奨' });
+const bestTodayAnalyticsPayload = buildPriceAnalyticsPayload(bestToday, bestToday?.store);
+const bestRecommendedAnalyticsPayload = buildPriceAnalyticsPayload(bestRecommended, bestRecommended?.store);
 
 const hasRecommendedSection = Boolean(skuInfo?.brandHints?.length);
 const bestTodayEffectiveValue = getEffectiveValue(bestToday);
@@ -210,6 +215,52 @@ function truncateShopName(name, maxLength = 20) {
     return name;
   }
   return `${name.slice(0, maxLength)}…`;
+}
+
+function buildPriceAnalyticsPayload(item, storeHint) {
+  if (!item) return null;
+
+  const payload = {
+    sku,
+  };
+
+  const storeValue = typeof item.store === 'string' && item.store.trim()
+    ? item.store.trim()
+    : (typeof storeHint === 'string' && storeHint.trim() ? storeHint.trim() : undefined);
+  if (storeValue) {
+    payload.store = storeValue;
+  }
+
+  if (item.shopName) {
+    payload.shop_name = item.shopName;
+  }
+
+  const priceValue = Number(item.price);
+  if (Number.isFinite(priceValue)) {
+    payload.price = priceValue;
+  }
+
+  const effectiveValue = getEffectivePriceValue(item);
+  if (Number.isFinite(effectiveValue)) {
+    payload.effective_price = effectiveValue;
+  }
+
+  const targetUrl = typeof item.itemUrl === 'string' ? item.itemUrl : '';
+  if (targetUrl) {
+    try {
+      const url = new URL(targetUrl);
+      const source = url.searchParams.get('utm_source');
+      const medium = url.searchParams.get('utm_medium');
+      const campaign = url.searchParams.get('utm_campaign');
+      if (source) payload.utm_source = source;
+      if (medium) payload.utm_medium = medium;
+      if (campaign) payload.utm_campaign = campaign;
+    } catch {
+      /* noop */
+    }
+  }
+
+  return JSON.stringify(payload);
 }
 
 function getPriceCardModel(item, { prefix }) {
@@ -279,6 +330,9 @@ export function getStaticPaths() {
     <base href={BASE_URL} />
     <script is:inline set:html={clientGlobalsScript}></script>
     <title>{skuInfo ? skuInfo.q : sku} – 価格一覧</title>
+    {analyticsScript && (
+      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
+    )}
   </head>
 <body data-sku={sku}>
     <div class="wrap">
@@ -331,6 +385,8 @@ export function getStaticPaths() {
                           class="best-price-card__link"
                           title={bestTodayCard.shopTitle}
                           aria-label={getShopLinkDescription(bestTodayCard.shopName || bestTodayCard.shopDisplayName)}
+                          data-analytics={bestTodayAnalyticsPayload ? "price_click" : undefined}
+                          data-analytics-payload={bestTodayAnalyticsPayload ?? undefined}
                         >
                           {bestTodayCard.shopDisplayName} で確認 <span aria-hidden="true">↗</span>
                         </a>
@@ -372,20 +428,22 @@ export function getStaticPaths() {
                           )}
                         </p>
                       )}
-                      {bestRecommendedCard.itemUrl && (
-                        <p class="best-price-card__line best-price-card__line--link">
-                          <a
-                            href={bestRecommendedCard.itemUrl}
-                            target="_blank"
-                            rel="nofollow noopener"
-                            class="best-price-card__link"
-                            title={bestRecommendedCard.shopTitle}
-                            aria-label={getShopLinkDescription(bestRecommendedCard.shopName || bestRecommendedCard.shopDisplayName)}
-                          >
-                            {bestRecommendedCard.shopDisplayName} で確認 <span aria-hidden="true">↗</span>
-                          </a>
-                        </p>
-                      )}
+                    {bestRecommendedCard.itemUrl && ( 
+                      <p class="best-price-card__line best-price-card__line--link">
+                        <a
+                          href={bestRecommendedCard.itemUrl}
+                          target="_blank"
+                          rel="nofollow noopener"
+                          class="best-price-card__link"
+                          title={bestRecommendedCard.shopTitle}
+                          aria-label={getShopLinkDescription(bestRecommendedCard.shopName || bestRecommendedCard.shopDisplayName)}
+                          data-analytics={bestRecommendedAnalyticsPayload ? "price_click" : undefined}
+                          data-analytics-payload={bestRecommendedAnalyticsPayload ?? undefined}
+                        >
+                          {bestRecommendedCard.shopDisplayName} で確認 <span aria-hidden="true">↗</span>
+                        </a>
+                      </p>
+                    )}
                     </>
                   ) : (
                     <p class="best-price-card__line best-price-card__line--empty">該当なし</p>
@@ -504,6 +562,7 @@ export function getStaticPaths() {
                     {allList.map(it => {
                       const eff = Number.isFinite(it.effective) ? it.effective : getEffectivePriceValue(it);
                       const hasPointRate = Number(it.pointRate ?? 0) > 0;
+                      const analyticsPayload = buildPriceAnalyticsPayload(it, it.store);
                       return (
                         <tr class="has-store-badge" data-price={it.price} data-eff={eff}>
                           <td
@@ -558,6 +617,8 @@ export function getStaticPaths() {
                               rel="nofollow noopener"
                               title={getShopLinkDescription(it.shopName)}
                               aria-label={getShopLinkDescription(it.shopName)}
+                              data-analytics={analyticsPayload ? "price_click" : undefined}
+                              data-analytics-payload={analyticsPayload ?? undefined}
                             >
                               ショップで確認
                               <span aria-hidden="true" class="external-link-icon">↗</span>
@@ -596,6 +657,7 @@ export function getStaticPaths() {
                       {sec.list.map(it => {
                         const eff = Number.isFinite(it.effective) ? it.effective : getEffectivePriceValue(it);
                         const hasPointRate = Number(it.pointRate ?? 0) > 0;
+                        const analyticsPayload = buildPriceAnalyticsPayload(it, sec.name);
                         return (
                           <tr data-price={it.price} data-eff={eff}>
                             <td headers={`col-${sec.key}-shop`} data-label="ショップ" data-cell="shop">
@@ -629,6 +691,8 @@ export function getStaticPaths() {
                                 rel="nofollow noopener"
                                 title={getShopLinkDescription(it.shopName)}
                                 aria-label={getShopLinkDescription(it.shopName)}
+                                data-analytics={analyticsPayload ? "price_click" : undefined}
+                                data-analytics-payload={analyticsPayload ?? undefined}
                               >
                                 ショップで確認
                                 <span aria-hidden="true" class="external-link-icon">↗</span>
@@ -2259,5 +2323,6 @@ export function getStaticPaths() {
       )}
     </div>
     <Footer />
+    <AnalyticsRuntime />
   </body>
 </html>

--- a/src/pages/prices/index.astro
+++ b/src/pages/prices/index.astro
@@ -1,9 +1,12 @@
 ---
 import "../../styles/global.css";
+import AnalyticsRuntime from "../../components/AnalyticsRuntime.astro";
 import Footer from "../../components/Footer.astro";
 import skus from "../../data/skus.json";
+import { getAnalyticsScriptConfig } from "../../lib/analytics";
 import { safeBreak } from "../../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
+const analyticsScript = getAnalyticsScriptConfig();
 
 let data;
 let sourceStatus = "fail";
@@ -35,6 +38,9 @@ const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <base href={BASE_URL} />
     <title>今日の最安“候補”</title>
+    {analyticsScript && (
+      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
+    )}
   </head>
   <body>
     <div class="wrap">
@@ -54,12 +60,25 @@ const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
           <p class="small jp-copy">取得日時: {new Date(data.updatedAt).toLocaleString('ja-JP')}</p>
           {data.sourceStatus && <p class="small jp-copy">対象ストア: 楽天市場、Yahoo!ショッピング</p>}
           <ul>
-            {data.items.map(it => (
-              <li>
-                <a href={`prices/${it.skuId}/`}>{skuMap[it.skuId]?.q ?? it.skuId}</a>
-                : {it.bestPrice}円 ({it.bestShop})
-              </li>
-            ))}
+            {data.items.map((it, index) => {
+              const analyticsPayload = JSON.stringify({
+                sku: it.skuId,
+                rank: index + 1,
+                from_page: "/prices/",
+              });
+              return (
+                <li>
+                  <a
+                    href={`prices/${it.skuId}/`}
+                    data-analytics="sku_card_click"
+                    data-analytics-payload={analyticsPayload}
+                  >
+                    {skuMap[it.skuId]?.q ?? it.skuId}
+                  </a>
+                  : {it.bestPrice}円 ({it.bestShop})
+                </li>
+              );
+            })}
           </ul>
         </>
       ) : (
@@ -67,5 +86,6 @@ const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
       )}
     </div>
     <Footer />
+    <AnalyticsRuntime />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable analytics helper and runtime to load Plausible when enabled
- instrument deals and prices pages with data attributes and custom event payloads
- document analytics environment variables and extend QA checks for the new tracking markers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfeecb0fc48326a881fa059f77f8b5