### PR TITLE
Bundle analytics runtime logic

### DIFF
--- a/src/components/AnalyticsRuntime.astro
+++ b/src/components/AnalyticsRuntime.astro
@@ -1,29 +1,10 @@
-<script type="module">
-  import { send } from '../lib/analytics';
+---
+import { getAnalyticsScriptConfig } from '../lib/analytics';
 
-  const parsePayload = (value) => {
-    if (!value) return undefined;
-    try {
-      return JSON.parse(value);
-    } catch {
-      return undefined;
-    }
-  };
+const analyticsConfig = getAnalyticsScriptConfig();
+---
 
-  const attach = (element) => {
-    if (!element) return;
-    if (element.dataset.analyticsBound === '1') return;
-    element.addEventListener('click', () => {
-      const eventName = element.getAttribute('data-analytics');
-      if (!eventName) {
-        return;
-      }
-      const payload = parsePayload(element.getAttribute('data-analytics-payload'));
-      send(eventName, payload);
-    });
-    element.dataset.analyticsBound = '1';
-  };
-
-  const elements = Array.from(document.querySelectorAll('[data-analytics]'));
-  elements.forEach((element) => attach(element));
-</script>
+{analyticsConfig && (
+  <script defer data-domain={analyticsConfig.domain} src={analyticsConfig.src}></script>
+)}
+<script type="module" src={Astro.resolve('../scripts/analytics-runtime.ts')}></script>

--- a/src/scripts/analytics-runtime.ts
+++ b/src/scripts/analytics-runtime.ts
@@ -1,0 +1,79 @@
+import { send, type AnalyticsProps } from '../lib/analytics';
+
+const ANALYTICS_SELECTOR = '[data-analytics]';
+
+const parsePayload = (value: string | null): AnalyticsProps | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(value) as AnalyticsProps;
+  } catch {
+    return undefined;
+  }
+};
+
+const attach = (element: Element | null) => {
+  if (!element || !(element instanceof HTMLElement)) {
+    return;
+  }
+  if (element.dataset.analyticsBound === '1') {
+    return;
+  }
+  element.addEventListener('click', () => {
+    const eventName = element.dataset.analytics;
+    if (!eventName) {
+      return;
+    }
+    const payload = parsePayload(element.getAttribute('data-analytics-payload'));
+    send(eventName, payload);
+  });
+  element.dataset.analyticsBound = '1';
+};
+
+const attachAll = (root: ParentNode) => {
+  const elements = root.querySelectorAll(ANALYTICS_SELECTOR);
+  elements.forEach((element) => attach(element));
+};
+
+const handleAddedNode = (node: Node) => {
+  if (node instanceof Element) {
+    if (node.matches(ANALYTICS_SELECTOR)) {
+      attach(node);
+    }
+    attachAll(node);
+    return;
+  }
+  if (node instanceof DocumentFragment) {
+    attachAll(node);
+  }
+};
+
+const observeMutations = () => {
+  if (typeof MutationObserver === 'undefined') {
+    return;
+  }
+  const body = document.body;
+  if (!body) {
+    return;
+  }
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      mutation.addedNodes.forEach((node) => handleAddedNode(node));
+    }
+  });
+  observer.observe(body, { childList: true, subtree: true });
+};
+
+const init = () => {
+  attachAll(document);
+  observeMutations();
+};
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+}


### PR DESCRIPTION
## Summary
- bundle the analytics runtime logic into a dedicated client script loaded via Astro.resolve
- keep the Plausible analytics script injection based on getAnalyticsScriptConfig
- add MutationObserver support so dynamically inserted analytics targets are instrumented

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1e4adbcc883268e6251d75119401e