### PR TITLE
Centralize Plausible script injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "pipeline": "node pipelines/run-all.mjs",
     "test": "echo \"no tests yet\" && exit 0",
     "pretest:a11y": "npm run build && node scripts/prepare-lhci-dist.mjs && node scripts/setup-playwright.mjs",
-    "test:a11y": "node scripts/run-lhci.mjs"
+    "test:a11y": "node scripts/run-lhci.mjs",
+    "qa:analytics": "node scripts/run-analytics-qa.mjs"
   },
   "dependencies": {
     "astro": "^4.13.0",

--- a/scripts/run-analytics-qa.mjs
+++ b/scripts/run-analytics-qa.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { chromium } from 'playwright';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(currentDir, '..');
+const distDir = join(projectRoot, 'dist');
+
+const pages = [
+  { name: 'index', segments: ['index.html'] },
+  { name: 'deals', segments: ['deals', 'index.html'] },
+  { name: 'calculators', segments: ['calculators', 'index.html'] },
+];
+
+function assertBuildOutput() {
+  if (!existsSync(distDir)) {
+    console.error('dist directory not found. Run "npm run build" before executing QA checks.');
+    process.exit(1);
+  }
+}
+
+assertBuildOutput();
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+const issues = [];
+const results = [];
+
+for (const { name, segments } of pages) {
+  const filePath = join(distDir, ...segments);
+  if (!existsSync(filePath)) {
+    issues.push(`dist/${segments.join('/')} not found for ${name} page.`);
+    continue;
+  }
+
+  const fileUrl = pathToFileURL(filePath).href;
+  await page.goto(fileUrl, { waitUntil: 'load' });
+
+  const scriptCount = await page.evaluate(() =>
+    document.querySelectorAll('script[src*="plausible.io/js/script"]').length
+  );
+
+  results.push({ name, scriptCount });
+
+  if (scriptCount > 1) {
+    issues.push(`${name} page has ${scriptCount} Plausible scripts. Expected at most 1.`);
+  }
+}
+
+await browser.close();
+
+if (issues.length) {
+  console.error('Analytics QA failed:');
+  for (const issue of issues) {
+    console.error(`- ${issue}`);
+  }
+  process.exit(1);
+}
+
+for (const { name, scriptCount } of results) {
+  console.log(`${name}: ${scriptCount} Plausible script tag(s)`);
+}
+
+console.log('Analytics QA passed.');

--- a/src/components/AnalyticsRuntime.astro
+++ b/src/components/AnalyticsRuntime.astro
@@ -1,14 +1,8 @@
 ---
 // 先頭に追加
-import { getAnalyticsScriptConfig, isAnalyticsEnabled } from '../lib/analytics';
+import { isAnalyticsEnabled } from '../lib/analytics';
 import runtimeUrl from '../scripts/analytics-runtime.ts?url';
 
-const cfg = getAnalyticsScriptConfig();
 const enabled = isAnalyticsEnabled();
 ---
-{cfg && (
-  <script defer data-domain={cfg.domain} src={cfg.src}></script>
-)}
-{enabled && (
-  <script type="module" src={runtimeUrl}></script>
-)}
+{enabled && <script type="module" src={runtimeUrl}></script>}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,0 +1,27 @@
+---
+import '../styles/global.css';
+import { getAnalyticsScriptConfig } from '../lib/analytics';
+
+export interface Props {
+  title?: string;
+}
+
+const { title }: Props = Astro.props;
+const BASE_URL = import.meta.env.BASE_URL;
+const analyticsScript = getAnalyticsScriptConfig();
+---
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <base href={BASE_URL} />
+    {title && <title>{title}</title>}
+    <slot name="head" />
+    {analyticsScript && (
+      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
+    )}
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/src/pages/calculators.astro
+++ b/src/pages/calculators.astro
@@ -1,21 +1,13 @@
 ---
-import "../styles/global.css";
+import Layout from "../layouts/Layout.astro";
 import Footer from "../components/Footer.astro";
 import { safeBreak } from "../lib/safe-break";
-const BASE_URL = import.meta.env.BASE_URL;
 ---
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <base href={BASE_URL} />
-    <title>なんでも計算室</title>
-  </head>
-  <body>
-    <div class="wrap">
-      <a href="./" class="small">← トップ</a>
-      <h1 set:html={safeBreak("なんでも計算室")}></h1>
-      <div class="grid">
+<Layout title="なんでも計算室">
+  <div class="wrap">
+    <a href="./" class="small">← トップ</a>
+    <h1 set:html={safeBreak("なんでも計算室")}></h1>
+    <div class="grid">
 
         <div class="card">
           <h2 set:html={safeBreak("税込↔税抜")}></h2>
@@ -55,10 +47,10 @@ const BASE_URL = import.meta.env.BASE_URL;
           <div class="result" id="r5"></div>
         </div>
 
-      </div>
     </div>
-    <Footer />
-    <script>
+  </div>
+  <Footer />
+  <script>
       const $ = (s) => document.querySelector(s);
 
       function fmt(n){ return Number.isFinite(n) ? n.toLocaleString(undefined,{maximumFractionDigits:2}) : "-"; }
@@ -114,6 +106,5 @@ const BASE_URL = import.meta.env.BASE_URL;
         $("#r5").textContent = `${fmt(kcal)} kcal / ${fmt(kj)} kJ`;
       }
       ["#val5","#u5"].forEach(id=>$(id).addEventListener("input",calc5)); calc5();
-    </script>
-  </body>
-</html>
+  </script>
+</Layout>

--- a/src/pages/deals.astro
+++ b/src/pages/deals.astro
@@ -1,17 +1,14 @@
 ---
-import "../styles/global.css";
+import Layout from "../layouts/Layout.astro";
 import AnalyticsRuntime from "../components/AnalyticsRuntime.astro";
 import Footer from "../components/Footer.astro";
 import data from "../data/deals.json";
 import rssSources from "../../data-sources/rss.json";
-import { getAnalyticsScriptConfig } from "../lib/analytics";
 import { safeBreak } from "../lib/safe-break";
 import { guessSkuFromDeal } from "../lib/sku-map.mjs";
 import { buildLink } from "../../scripts/link-builder.mjs";
 
-const BASE_URL = import.meta.env.BASE_URL;
 const items = (data?.items ?? []).slice(0, 100);
-const analyticsScript = getAnalyticsScriptConfig();
 
 const dtf = new Intl.DateTimeFormat("ja-JP", {
   timeZone: "Asia/Tokyo",
@@ -231,19 +228,11 @@ const dealsStructuredData = {
 
 const dealsSchemaJson = JSON.stringify(dealsStructuredData, null, 2);
 ---
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <base href={BASE_URL} />
-    <title>今日のセール・割引まとめ</title>
+<Layout title="今日のセール・割引まとめ">
+  <Fragment slot="head">
     <script type="application/ld+json" data-schema="deal-list" set:html={dealsSchemaJson}></script>
-    {analyticsScript && (
-      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
-    )}
-  </head>
-  <body>
-    <div class="wrap">
+  </Fragment>
+  <div class="wrap">
       <a href="./" class="small">← トップ</a>
       <h1 set:html={safeBreak("今日のセール・割引まとめ")}></h1>
       <p class="small jp-copy">主要サイトの公式情報から毎日自動で集めています。ノイズ（求人・PR等）は除外。</p>
@@ -431,8 +420,7 @@ const dealsSchemaJson = JSON.stringify(dealsStructuredData, null, 2);
         applySort();
         applyFilters();
       </script>
-    </div>
-    <Footer />
-    <AnalyticsRuntime />
-  </body>
-</html>
+  </div>
+  <Footer />
+  <AnalyticsRuntime />
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,8 @@
 ---
-import "../styles/global.css";
+import Layout from "../layouts/Layout.astro";
 import Footer from "../components/Footer.astro";
 import AnalyticsRuntime from "../components/AnalyticsRuntime.astro";
-import { getAnalyticsScriptConfig } from "../lib/analytics";
 import { safeBreak } from "../lib/safe-break";
-const BASE_URL = import.meta.env.BASE_URL;
-const analyticsScript = getAnalyticsScriptConfig();
 const tools = [
   {
     href: "calculators/",
@@ -27,33 +24,22 @@ const tools = [
   },
 ];
 ---
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <base href={BASE_URL} />
-    <title>なんでも計算室＆お得チェッカー</title>
-    {analyticsScript && (
-      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
-    )}
-  </head>
-  <body>
-    <div class="wrap">
-      <h1 set:html={safeBreak("なんでも計算室＆お得チェッカー")}></h1>
-      <p class="small jp-copy">
-        よく使う計算と今日のお得をまとめてチェック。
-      </p>
-      <div class="grid" style="margin-top:20px">
-        {tools.map(t => (
-          <a class="card" href={t.href}>
-            <h2 set:html={safeBreak(t.title)}></h2>
-            <p class="jp-copy">{t.desc}</p>
-            <span class="btn">{t.cta ?? "開く"}</span>
-          </a>
-        ))}
-      </div>
+<Layout title="なんでも計算室＆お得チェッカー">
+  <div class="wrap">
+    <h1 set:html={safeBreak("なんでも計算室＆お得チェッカー")}></h1>
+    <p class="small jp-copy">
+      よく使う計算と今日のお得をまとめてチェック。
+    </p>
+    <div class="grid" style="margin-top:20px">
+      {tools.map(t => (
+        <a class="card" href={t.href}>
+          <h2 set:html={safeBreak(t.title)}></h2>
+          <p class="jp-copy">{t.desc}</p>
+          <span class="btn">{t.cta ?? "開く"}</span>
+        </a>
+      ))}
     </div>
-    <Footer />
-    <AnalyticsRuntime />
-  </body>
-</html>
+  </div>
+  <Footer />
+  <AnalyticsRuntime />
+</Layout>


### PR DESCRIPTION
## Summary
- add a shared layout that injects the Plausible script once per page and load the runtime conditionally
- update key pages to consume the new layout while keeping analytics events wired up
- add a Playwright QA script to verify Plausible appears at most once per major page

## Testing
- npm run build
- npm run qa:analytics

------
https://chatgpt.com/codex/tasks/task_e_68e237459fdc83269c38c13dfa5415d8