### PR TITLE
Add opt-in price history backfill and cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,12 @@ PUBLIC_ANALYTICS_SRC=https://plausible.io/js/script.js
 | `price_click` | `/prices/[sku]/` の「ショップで確認」ボタンをクリックしたとき | `sku`, `store`, `shop_name`, `price`, `effective_price`, `utm_source`, `utm_medium`, `utm_campaign` |
 
 `PUBLIC_ANALYTICS_PROVIDER=plausible` が設定されていれば、各イベントは `window.plausible()` を通じて送信されます。
+
+## 価格履歴のバックフィルとクリーニング
+
+Rakuten/Yahoo の集計結果をマージする `pipelines/prices-merge.mjs` では、オプトインで既存の価格履歴をクリーンアップできます。
+
+- `ENABLE_HISTORY_BACKFILL=true` を設定すると、`meta.valueType` が `effectivePrice` 以外のファイルでも当日以降は強制的に効果価格で上書きし、IQR ベースの外れ値を除外したうえで `meta.cleaned=true` を付与します。
+- `DRY_RUN=true` を併用するとファイルへの書き込みは行わず、差分のみをログ出力します。
+
+本番に適用する際はまず `DRY_RUN=true` を指定して差分を確認してから、問題がなければ `DRY_RUN` を外して再実行してください。

--- a/pipelines/prices-merge.mjs
+++ b/pipelines/prices-merge.mjs
@@ -53,11 +53,23 @@ function cleanHistoryEntries(entries) {
   let upperBound = q3 + 1.5 * iqr;
   if (!Number.isFinite(lowerBound)) lowerBound = 0;
   if (!Number.isFinite(upperBound)) upperBound = Number.POSITIVE_INFINITY;
+  const positivePrices = prices.filter(price => price > 0);
   if (Number.isFinite(median) && median > 0) {
     const ratioLower = median / 4;
     const ratioUpper = median * 4;
     lowerBound = Math.min(lowerBound, ratioLower);
     upperBound = Math.max(upperBound, ratioUpper);
+  } else if (positivePrices.length > 0) {
+    const positiveQ1 = quantile(positivePrices, 0.25);
+    const positiveQ3 = quantile(positivePrices, 0.75);
+    const positiveIqr = positiveQ3 - positiveQ1;
+    let positiveUpper = positiveQ3 + 1.5 * positiveIqr;
+    if (!Number.isFinite(positiveUpper) || positiveUpper <= 0) {
+      positiveUpper = positivePrices[positivePrices.length - 1];
+    }
+    const minPositive = positivePrices[0];
+    const expandedUpper = Math.max(positiveUpper, minPositive * 4);
+    upperBound = Math.max(upperBound, expandedUpper);
   }
   lowerBound = Math.max(0, lowerBound);
   const absoluteUpper = 5_000_000;


### PR DESCRIPTION
## Summary
- add IQR-based cleaner and dry-run logging for price history updates
- gate backfill/clean-up behind ENABLE_HISTORY_BACKFILL with documentation in the README

## Testing
- ENABLE_HISTORY_BACKFILL=true DRY_RUN=true node pipelines/prices-merge.mjs
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3aaa4ac3483268bea8ad9da703e9a