### PR TITLE
Configure robots directives by deploy target

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,16 +4,22 @@ import { getAnalyticsScriptConfig } from '../lib/analytics';
 
 export interface Props {
   title?: string;
+  bodyAttributes?: Record<string, string>;
 }
 
-const { title }: Props = Astro.props;
+const { title, bodyAttributes = {} }: Props = Astro.props;
 const BASE_URL = import.meta.env.BASE_URL;
 const analyticsScript = getAnalyticsScriptConfig();
+const isProdDeploy = import.meta.env.PUBLIC_DEPLOY_TARGET === 'prod';
 ---
 <html lang="ja">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="robots"
+      content={isProdDeploy ? 'index, follow' : 'noindex, nofollow'}
+    />
     <base href={BASE_URL} />
     {title && <title>{title}</title>}
     <slot name="head" />
@@ -21,7 +27,7 @@ const analyticsScript = getAnalyticsScriptConfig();
       <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
     )}
   </head>
-  <body>
+  <body {...bodyAttributes}>
     <slot />
   </body>
 </html>

--- a/src/pages/about/affiliate.astro
+++ b/src/pages/about/affiliate.astro
@@ -1,33 +1,19 @@
 ---
-import "../../styles/global.css";
+import Layout from "../../layouts/Layout.astro";
 import AnalyticsRuntime from "../../components/AnalyticsRuntime.astro";
 import Footer from "../../components/Footer.astro";
-import { getAnalyticsScriptConfig } from "../../lib/analytics";
 import { safeBreak } from "../../lib/safe-break";
-const BASE_URL = import.meta.env.BASE_URL;
-const analyticsScript = getAnalyticsScriptConfig();
 ---
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <base href={BASE_URL} />
-    <title>アフィリエイトについて</title>
-    {analyticsScript && (
-      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
-    )}
-  </head>
-  <body>
-    <div class="wrap">
-      <a href="./" class="small">← トップ</a>
-      <h1 set:html={safeBreak("アフィリエイトについて")}></h1>
-      <p class="jp-copy">一部のリンクはアフィリエイトリンクを含みます。購入により、運営に紹介料が支払われる場合があります。</p>
-      <p class="jp-copy">紹介料は商品価格やお客様の負担に影響しません。</p>
-      <p class="jp-copy">本サイトの掲載順・評価は、取得時点の情報（価格・在庫・仕様）と独自ルール（ノイズ除外など）に基づきます。</p>
-      <p class="jp-copy">購入の最終判断は、必ずリンク先の最新情報をご確認ください。</p>
-      <p class="small jp-copy">サイトの利用状況はCookieレス分析ツール（Plausible）で匿名集計しています。</p>
-    </div>
-    <Footer />
-    <AnalyticsRuntime />
-  </body>
-</html>
+<Layout title="アフィリエイトについて">
+  <div class="wrap">
+    <a href="./" class="small">← トップ</a>
+    <h1 set:html={safeBreak("アフィリエイトについて")}></h1>
+    <p class="jp-copy">一部のリンクはアフィリエイトリンクを含みます。購入により、運営に紹介料が支払われる場合があります。</p>
+    <p class="jp-copy">紹介料は商品価格やお客様の負担に影響しません。</p>
+    <p class="jp-copy">本サイトの掲載順・評価は、取得時点の情報（価格・在庫・仕様）と独自ルール（ノイズ除外など）に基づきます。</p>
+    <p class="jp-copy">購入の最終判断は、必ずリンク先の最新情報をご確認ください。</p>
+    <p class="small jp-copy">サイトの利用状況はCookieレス分析ツール（Plausible）で匿名集計しています。</p>
+  </div>
+  <Footer />
+  <AnalyticsRuntime />
+</Layout>

--- a/src/pages/about/sources.astro
+++ b/src/pages/about/sources.astro
@@ -1,37 +1,23 @@
 ---
-import "../../styles/global.css";
+import Layout from "../../layouts/Layout.astro";
 import AnalyticsRuntime from "../../components/AnalyticsRuntime.astro";
 import Footer from "../../components/Footer.astro";
-import { getAnalyticsScriptConfig } from "../../lib/analytics";
 import { safeBreak } from "../../lib/safe-break";
-const BASE_URL = import.meta.env.BASE_URL;
-const analyticsScript = getAnalyticsScriptConfig();
 ---
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <base href={BASE_URL} />
-    <title>データ出典と更新について</title>
-    {analyticsScript && (
-      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
-    )}
-  </head>
-  <body>
-    <div class="wrap">
-      <a href="./" class="small">← トップ</a>
-      <h1 set:html={safeBreak("データ出典と更新について")}></h1>
-      <p class="jp-copy">本サイトはメーカーや公式ストアの情報を、公式RSS・公式APIを中心に毎日自動で取り込み、必要に応じて最新成功分を表示しています。</p>
-      <h2 set:html={safeBreak("ノイズ除外の基準")}></h2>
-      <ul>
-        <li>求人・提供／PRなど、価格比較に直接関係しない投稿</li>
-        <li>重複告知や機械的な再投稿</li>
-        <li>価格・在庫など判断材料が欠けている告知</li>
-      </ul>
-      <p class="small jp-copy">価格・在庫は取得時点の参考値です。最新情報は各リンク先をご確認ください。</p>
-      <p class="small jp-copy">解析や取得方法など技術的な詳細は予告なく調整される場合があります。</p>
-    </div>
-    <Footer />
-    <AnalyticsRuntime />
-  </body>
-</html>
+<Layout title="データ出典と更新について">
+  <div class="wrap">
+    <a href="./" class="small">← トップ</a>
+    <h1 set:html={safeBreak("データ出典と更新について")}></h1>
+    <p class="jp-copy">本サイトはメーカーや公式ストアの情報を、公式RSS・公式APIを中心に毎日自動で取り込み、必要に応じて最新成功分を表示しています。</p>
+    <h2 set:html={safeBreak("ノイズ除外の基準")}></h2>
+    <ul>
+      <li>求人・提供／PRなど、価格比較に直接関係しない投稿</li>
+      <li>重複告知や機械的な再投稿</li>
+      <li>価格・在庫など判断材料が欠けている告知</li>
+    </ul>
+    <p class="small jp-copy">価格・在庫は取得時点の参考値です。最新情報は各リンク先をご確認ください。</p>
+    <p class="small jp-copy">解析や取得方法など技術的な詳細は予告なく調整される場合があります。</p>
+  </div>
+  <Footer />
+  <AnalyticsRuntime />
+</Layout>

--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -1,16 +1,14 @@
 ---
-import "../../styles/global.css";
+import Layout from "../../layouts/Layout.astro";
 import AnalyticsRuntime from "../../components/AnalyticsRuntime.astro";
 import Footer from "../../components/Footer.astro";
 import skus from "../../data/skus.json";
-import { getAnalyticsScriptConfig } from "../../lib/analytics";
 import { safeBreak } from "../../lib/safe-break";
 import { isDealRelatedToSku } from "../../lib/sku-map.mjs";
 import { buildLink } from "../../../scripts/link-builder.mjs";
 const IS_DEV = import.meta.env.DEV;
 const BASE_URL = import.meta.env.BASE_URL;
 const clientGlobalsScript = `window.__APP_DEV__ = ${JSON.stringify(IS_DEV)};\nwindow.__BASE_URL__ = ${JSON.stringify(BASE_URL)};`;
-const analyticsScript = getAnalyticsScriptConfig();
 
 let data;
 let rakutenData;
@@ -60,6 +58,13 @@ const { sku } = Astro.params;
 const skuInfo = skus.find(s => s.id === sku);
 const priceInfo = data?.items?.find(i => i.skuId === sku);
 const dealsItems = Array.isArray(dealsFeed?.items) ? dealsFeed.items : [];
+const pageTitle = `${skuInfo ? skuInfo.q : sku} – 価格一覧`;
+const bodyAttributes: Record<string, string> = {
+  'data-sku': sku ?? '',
+};
+if (Array.isArray(skuInfo?.brandHints) && skuInfo.brandHints.length > 0) {
+  bodyAttributes['data-brand-hints'] = JSON.stringify(skuInfo.brandHints);
+}
 
 const dealDateFormatter = new Intl.DateTimeFormat("ja-JP", {
   timeZone: "Asia/Tokyo",
@@ -492,22 +497,14 @@ export function getStaticPaths() {
   return skus.map(s => ({ params: { sku: s.id } }));
 }
 ---
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <base href={BASE_URL} />
+<Layout title={pageTitle} bodyAttributes={bodyAttributes}>
+  <Fragment slot="head">
     <script is:inline set:html={clientGlobalsScript}></script>
-    <title>{skuInfo ? skuInfo.q : sku} – 価格一覧</title>
-    {analyticsScript && (
-      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
-    )}
     {productStructuredDataScript && (
       <script type="application/ld+json" is:inline set:html={productStructuredDataScript}></script>
     )}
-  </head>
-<body data-sku={sku} data-brand-hints={skuInfo?.brandHints ? JSON.stringify(skuInfo.brandHints) : undefined}>
-    <div class="wrap">
+  </Fragment>
+  <div class="wrap">
         <a href="./" class="small">← トップ</a>
       <h1 set:html={safeBreak(`${skuInfo ? skuInfo.q : sku} – 価格一覧`)}></h1>
       <p class="jp-copy">ショップ別の価格一覧です。実質価格（ポイント込み）で安い順に並べています。</p>
@@ -2840,8 +2837,7 @@ export function getStaticPaths() {
       ) : (
         <p>データ少</p>
       )}
-    </div>
-    <Footer />
-    <AnalyticsRuntime />
-  </body>
-</html>
+  </div>
+  <Footer />
+  <AnalyticsRuntime />
+</Layout>

--- a/src/pages/prices/index.astro
+++ b/src/pages/prices/index.astro
@@ -1,12 +1,10 @@
 ---
-import "../../styles/global.css";
+import Layout from "../../layouts/Layout.astro";
 import AnalyticsRuntime from "../../components/AnalyticsRuntime.astro";
 import Footer from "../../components/Footer.astro";
 import skus from "../../data/skus.json";
-import { getAnalyticsScriptConfig } from "../../lib/analytics";
 import { safeBreak } from "../../lib/safe-break";
 const BASE_URL = import.meta.env.BASE_URL;
-const analyticsScript = getAnalyticsScriptConfig();
 
 let data;
 let sourceStatus = "fail";
@@ -32,18 +30,8 @@ if (data?.sourceStatus) {
 }
 const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
 ---
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <base href={BASE_URL} />
-    <title>今日の最安“候補”</title>
-    {analyticsScript && (
-      <script defer data-domain={analyticsScript.domain} src={analyticsScript.src}></script>
-    )}
-  </head>
-  <body>
-    <div class="wrap">
+<Layout title="今日の最安“候補”">
+  <div class="wrap">
       {sourceStatus !== "ok" && (
         <div role="status" aria-live="polite" class="notice--warn" data-source-status={sourceStatus}>
           ⚠︎ {sourceStatus === "partial"
@@ -84,8 +72,7 @@ const skuMap = Object.fromEntries(skus.map(s => [s.id, s]));
       ) : (
         <p>データ少</p>
       )}
-    </div>
-    <Footer />
-    <AnalyticsRuntime />
-  </body>
-</html>
+  </div>
+  <Footer />
+  <AnalyticsRuntime />
+</Layout>

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -2,6 +2,8 @@ import type { APIRoute } from "astro";
 
 const isProdDeploy = import.meta.env.PUBLIC_DEPLOY_TARGET === "prod";
 
+const BASE_URL = import.meta.env.BASE_URL || "/";
+
 export const GET: APIRoute = ({ url }) => {
   if (!isProdDeploy) {
     const disallowAll = "User-agent: *\nDisallow: /";
@@ -13,7 +15,8 @@ export const GET: APIRoute = ({ url }) => {
     });
   }
 
-  const sitemapUrl = new URL("sitemap.xml", url.origin).toString();
+  const siteBase = new URL(BASE_URL, url.origin);
+  const sitemapUrl = new URL("sitemap.xml", siteBase).toString();
   const content = `User-agent: *\nAllow: /\nSitemap: ${sitemapUrl}`;
   return new Response(content, {
     headers: {

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -2,7 +2,8 @@ import type { APIRoute } from "astro";
 
 const isProdDeploy = import.meta.env.PUBLIC_DEPLOY_TARGET === "prod";
 
-const BASE_URL = import.meta.env.BASE_URL || "/";
+const RAW_BASE_URL = import.meta.env.BASE_URL || "/";
+const BASE_URL = RAW_BASE_URL.endsWith("/") ? RAW_BASE_URL : `${RAW_BASE_URL}/`;
 
 export const GET: APIRoute = ({ url }) => {
   if (!isProdDeploy) {

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from "astro";
+
+const isProdDeploy = import.meta.env.PUBLIC_DEPLOY_TARGET === "prod";
+
+export const GET: APIRoute = ({ url }) => {
+  if (!isProdDeploy) {
+    const disallowAll = "User-agent: *\nDisallow: /";
+    return new Response(disallowAll, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  const sitemapUrl = new URL("sitemap.xml", url.origin).toString();
+  const content = `User-agent: *\nAllow: /\nSitemap: ${sitemapUrl}`;
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from "astro";
+import skus from "../data/skus.json";
+
+const isProdDeploy = import.meta.env.PUBLIC_DEPLOY_TARGET === "prod";
+
+function buildUrl(origin: string, path: string) {
+  return new URL(path, origin).toString();
+}
+
+export const GET: APIRoute = ({ url }) => {
+  if (!isProdDeploy) {
+    return new Response(null, { status: 404 });
+  }
+
+  const staticPaths = [
+    "",
+    "calculators/",
+    "deals/",
+    "prices/",
+    "about/affiliate/",
+    "about/sources/",
+  ];
+
+  const skuPaths = Array.isArray(skus)
+    ? skus
+        .map(sku => sku?.id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0)
+        .map(id => `prices/${id}/`)
+    : [];
+
+  const allPaths = Array.from(new Set([...staticPaths, ...skuPaths]));
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${allPaths
+    .map(path => `  <url><loc>${buildUrl(url.origin, path)}</loc></url>`)
+    .join("\n")}\n</urlset>`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -2,9 +2,11 @@ import type { APIRoute } from "astro";
 import skus from "../data/skus.json";
 
 const isProdDeploy = import.meta.env.PUBLIC_DEPLOY_TARGET === "prod";
+const BASE_URL = import.meta.env.BASE_URL || "/";
 
 function buildUrl(origin: string, path: string) {
-  return new URL(path, origin).toString();
+  const siteBase = new URL(BASE_URL, origin);
+  return new URL(path, siteBase).toString();
 }
 
 export const GET: APIRoute = ({ url }) => {

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -2,7 +2,8 @@ import type { APIRoute } from "astro";
 import skus from "../data/skus.json";
 
 const isProdDeploy = import.meta.env.PUBLIC_DEPLOY_TARGET === "prod";
-const BASE_URL = import.meta.env.BASE_URL || "/";
+const RAW_BASE_URL = import.meta.env.BASE_URL || "/";
+const BASE_URL = RAW_BASE_URL.endsWith("/") ? RAW_BASE_URL : `${RAW_BASE_URL}/`;
 
 function buildUrl(origin: string, path: string) {
   const siteBase = new URL(BASE_URL, origin);


### PR DESCRIPTION
## Summary
- enforce the robots meta tag from the shared layout based on PUBLIC_DEPLOY_TARGET
- expose robots.txt and sitemap.xml only for production builds and return disallow/404 elsewhere
- refactor standalone pages to use the shared layout so they inherit the deploy-aware head logic

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e47df538848326a10fa80beeb07e6b