### PR TITLE
Ensure analytics env vars are injected during Pages build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: Test and Build
     runs-on: ubuntu-latest
+    env:
+      PUBLIC_ANALYTICS_PROVIDER: ${{ vars.PUBLIC_ANALYTICS_PROVIDER || 'plausible' }}
+      PUBLIC_ANALYTICS_DOMAIN: ${{ vars.PUBLIC_ANALYTICS_DOMAIN || 'panappuom.github.io' }}
+      PUBLIC_ANALYTICS_SRC: ${{ vars.PUBLIC_ANALYTICS_SRC || 'https://plausible.io/js/script.js' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -7,16 +7,22 @@
 
 ## アクセス解析の有効化
 
-Plausible を利用した Cookie レス計測をサポートしています。計測を有効化するには以下の公開環境変数を設定してください。
+Plausible を利用した Cookie レス計測をサポートしています。GitHub Pages へのデプロイ時に `PUBLIC_ANALYTICS_*` の各変数を確実に注入することが重要です。
 
-```
-PUBLIC_ANALYTICS_PROVIDER=plausible
-PUBLIC_ANALYTICS_DOMAIN=<your-plausible-domain>
-# 任意: 独自ホストしたスクリプトを使う場合のみ
-PUBLIC_ANALYTICS_SRC=https://plausible.io/js/script.js
-```
+### GitHub Actions での準備
+
+1. リポジトリの **Settings → Actions → Variables** を開き、次の3変数を登録します。
+   - `PUBLIC_ANALYTICS_PROVIDER`（通常は `plausible`）
+   - `PUBLIC_ANALYTICS_DOMAIN`（Plausible 上で計測するドメイン。例: `panappuom.github.io`）
+   - `PUBLIC_ANALYTICS_SRC`（任意。独自ホストしたスクリプトを使う場合のみ。既定は `https://plausible.io/js/script.js`）
+2. `.github/workflows/deploy.yml` の `test-build` ジョブでは、上記の変数を `env` として Astro のビルドコマンドに渡しています。**Workflow に `env` を設定し忘れるとビルド済み HTML にスクリプトが挿入されないので注意してください。**
 
 `PUBLIC_ANALYTICS_PROVIDER` を `none`（既定値）にすると計測は無効化され、スクリプトは読み込まれません。
+
+### 動作確認のヒント
+
+- ローカルビルドや Actions 上のビルド結果を確認すると、生成された HTML の `<head>` に `<script defer data-domain="..." src="..."></script>` が1回だけ出力されます。
+- GitHub Pages では `/calc-hub/` のようなサブパス配信でも Plausible の計測が動作します。`Verify` ボタンはサブパス環境では失敗することがあるため、代わりに Plausible の **Realtime** ビューで PV/イベントが流れることを確認してください（AdBlock を無効化した状態でアクセスする）。
 
 ### 送信イベント一覧
 


### PR DESCRIPTION
## Summary
- inject PUBLIC_ANALYTICS_* env variables into the deploy workflow so the Astro build always sees them
- document the Actions variable setup and Plausible verification guidance in the README

## Testing
- PUBLIC_ANALYTICS_PROVIDER=plausible PUBLIC_ANALYTICS_DOMAIN=panappuom.github.io PUBLIC_ANALYTICS_SRC=https://plausible.io/js/script.js npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4ea3747b0832682a0deb03e1eba53