### PR TITLE
Fix effective price detection for price display consistency

### DIFF
--- a/src/pages/prices/[sku].astro
+++ b/src/pages/prices/[sku].astro
@@ -157,14 +157,33 @@ const relatedDeals = dealsItems
   .sort((a, b) => b.timestamp - a.timestamp)
   .slice(0, 3);
 function getEffectivePriceValue(it) {
-  const price = Number(it?.price);
-  if (!Number.isFinite(price)) {
+  if (!it || typeof it !== 'object') {
     return Number.POSITIVE_INFINITY;
   }
-  const pointRate = Number(it?.pointRate ?? 0);
+
+  const explicitEffectiveFields = [
+    it.effective,
+    it.effectivePrice,
+    it.effective_price,
+    it.effective_value,
+  ];
+  for (const field of explicitEffectiveFields) {
+    const value = Number(field);
+    if (Number.isFinite(value) && value > 0) {
+      return Math.floor(value);
+    }
+  }
+
+  const price = Number(it.price);
+  if (!Number.isFinite(price) || price <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const pointRate = Number(it.pointRate ?? 0);
   if (!Number.isFinite(pointRate) || pointRate <= 0) {
     return Math.floor(price);
   }
+
   return Math.floor(price * (100 - pointRate) / 100);
 }
 


### PR DESCRIPTION
## Summary
- allow price cards to use precomputed effective price fields before falling back to point-rate calculations, keeping the best-price panel aligned with chart data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5c884dd948326a580a2133e8b1c39